### PR TITLE
Add ByPlaceholderTextError

### DIFF
--- a/src/queries/by_text.rs
+++ b/src/queries/by_text.rs
@@ -223,11 +223,10 @@ impl ByText for TestRender {
             );
 
             let iter = std::iter::from_fn(move || walker.next_node().ok().flatten())
-                .filter(|node| node.text_content().is_some());
+                .filter_map(|node| node.text_content().map(|text| (text, node)));
 
-            if let Some(closest) = util::closest(search, iter, |node| node.text_content().unwrap())
-            {
-                Err(ByTextError::Closest((search, closest)))
+            if let Some(closest) = util::closest(search, iter, |(key, _)| key) {
+                Err(ByTextError::Closest((search, closest.1)))
             } else {
                 Err(ByTextError::NotFound(search))
             }

--- a/src/util/lev_distance.rs
+++ b/src/util/lev_distance.rs
@@ -35,7 +35,7 @@ pub(crate) fn lev_distance(me: &str, t: &str) -> usize {
 pub(crate) fn closest<T, I, F>(search: &str, iter: I, to_key: F) -> Option<T>
 where
     I: Iterator<Item = T>,
-    F: Fn(&T) -> String,
+    F: Fn(&T) -> &String,
 {
     iter.map(|e| (lev_distance(search, &to_key(&e)), e))
         .filter(|&(d, _)| d < 4)
@@ -52,9 +52,9 @@ mod tests {
     fn test_probable_typos() {
         assert_eq!(lev_distance("Click me", "Click me!"), 1);
 
-        let element_text_content = "Click Me!";
+        let element_text_content = "Click Me!".to_owned();
 
-        closest("Clik Me", [element_text_content].iter(), |s| s.to_string())
+        closest("Clik Me", [element_text_content].iter(), |s| s)
             .expect("'Clik Me' to find 'Click Me!' as a recommendation");
     }
 }


### PR DESCRIPTION
ByPlaceholderText query now returns a ByPlaceholderTextError in a Result
so that unwrapping will give a helpful panic message.