### PR TITLE
Add element value getter and setter functions

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -24,3 +24,17 @@ function format_raw(node, level) {
 
 	return node;
 }
+
+export function get_value(element) {
+	return element.value
+}
+
+export function set_value(element, value) {
+	if (element.value !== undefined) {
+		element.value = value;
+		// element.setAttribute("value", value);
+		return true;
+	} else {
+		return false;
+	}
+}

--- a/src/util/html.rs
+++ b/src/util/html.rs
@@ -1,9 +1,25 @@
-use wasm_bindgen::prelude::*;
+use wasm_bindgen::{prelude::*, JsCast};
 use web_sys::Element;
 
 #[wasm_bindgen(module = "/js/utils.js")]
 extern "C" {
     fn format(str: JsValue) -> JsValue;
+    fn get_value(element: &Element) -> JsValue;
+    fn set_value(element: &Element, value: JsValue) -> JsValue;
+}
+
+pub fn get_element_value<T: JsCast>(element: &T) -> Option<String> {
+    element
+        .dyn_ref::<Element>()
+        .and_then(|e| get_value(e).as_string())
+}
+
+pub fn set_element_value<T: JsCast>(element: &T, value: &str) -> bool {
+    if let Some(element) = element.dyn_ref::<Element>() {
+        JsValue::TRUE == set_value(element, value.into())
+    } else {
+        false
+    }
 }
 
 pub fn format_html(html: &str) -> String {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,7 @@
 mod html;
 mod lev_distance;
 
-pub(crate) use html::format_html;
-pub(crate) use html::format_html_with_closest;
+pub(crate) use html::{
+    format_html, format_html_with_closest, get_element_value, set_element_value,
+};
 pub(crate) use lev_distance::closest;


### PR DESCRIPTION
This allows sap to call get_element_value or set_element_value on any
JsCast type to avoid the requirement of trying to cast to input,
textarea, select in order to get or set the value.