### PR TITLE
Add EventTargetChanged trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ sap-yew = { path = "crates/sap-yew" }
 [dependencies.web-sys]
 version = "0.3.51"
 features = [
+	"Event",
+	"EventInit",
 	"HtmlImageElement",
 	"HtmlLabelElement",
 	"InputEvent",


### PR DESCRIPTION
Enables a convenient way for dispatching a `change` `Event`s to an `EventTarget` 