### PR TITLE
Move wait and effect_dom functions to sap-utils

### DIFF
--- a/crates/sap-mock/Cargo.toml
+++ b/crates/sap-mock/Cargo.toml
@@ -7,10 +7,11 @@ edition = "2018"
 serde = "1"
 wasm-bindgen = { version = "0.2.74", features = ["serde-serialize"] }
 js-sys = "0.3.51"
-wasm-bindgen-futures = "0.4.24"
 
 [dev-dependencies]
+wasm-bindgen-futures = "0.4.24"
 wasm-bindgen-test = "0.3.24"
+sap-utils = { path = "../sap-utils" }
 
 [dev-dependencies.web-sys] 
 version = "0.3.51"

--- a/crates/sap-mock/js/mock.js
+++ b/crates/sap-mock/js/mock.js
@@ -42,36 +42,6 @@ export function restore_fetch(original_fetch) {
 	fetch = original_fetch;
 }
 
-export function wait_promise(ms) {
-	return new Promise((resolve) => {
-		let wait = setTimeout(() => {
-			clearTimeout(wait);
-			resolve();
-		}, ms)
-	})
-}
-
-export function until_mutation(element, action, timeout) {
-	return new Promise((resolve, reject) => {
-		const observerOptions = {
-			childList: true,
-			attributes: true,
-			subtree: true,
-			characterData: true,
-		};
-
-		const observer = new MutationObserver(() => { resolve() });
-		observer.observe(element, observerOptions);
-		action()
-		if (timeout) {
-			let wait = setTimeout(() => {
-				clearTimeout(wait);
-				reject(`No change observed within the allotted time: ${timeout}ms.`);
-			}, timeout)
-		}
-	});
-}
-
 export function mock_websocket(conn_delay) {
 	let mock_controller = {
 		is_opened: false,

--- a/crates/sap-utils/Cargo.toml
+++ b/crates/sap-utils/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 
 [dependencies]
 wasm-bindgen = "0.2.74"
+js-sys = "0.3.51"
+wasm-bindgen-futures = "0.4.24"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.24"

--- a/crates/sap-utils/js/sap-utils.js
+++ b/crates/sap-utils/js/sap-utils.js
@@ -37,3 +37,33 @@ export function set_value(element, value) {
 		return false;
 	}
 }
+
+export function wait_promise(ms) {
+	return new Promise((resolve) => {
+		let wait = setTimeout(() => {
+			clearTimeout(wait);
+			resolve();
+		}, ms)
+	})
+}
+
+export function until_mutation(element, action, timeout) {
+	return new Promise((resolve, reject) => {
+		const observerOptions = {
+			childList: true,
+			attributes: true,
+			subtree: true,
+			characterData: true,
+		};
+
+		const observer = new MutationObserver(() => { resolve() });
+		observer.observe(element, observerOptions);
+		action()
+		if (timeout) {
+			let wait = setTimeout(() => {
+				clearTimeout(wait);
+				reject(`No change observed within the allotted time: ${timeout}ms.`);
+			}, timeout)
+		}
+	});
+}

--- a/crates/sap-utils/src/lib.rs
+++ b/crates/sap-utils/src/lib.rs
@@ -3,3 +3,66 @@ mod lev_distance;
 
 pub use html::{format_html, format_html_with_closest, get_element_value, set_element_value};
 pub use lev_distance::closest;
+
+use js_sys::Function;
+use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen_futures::JsFuture;
+
+#[wasm_bindgen(module = "/js/sap-utils.js")]
+extern "C" {
+    fn wait_promise(ms: JsValue) -> js_sys::Promise;
+    fn until_mutation(element: &JsValue, action: &Function, timeout: JsValue) -> js_sys::Promise;
+}
+
+/**
+Perform an action and await a DOM change with an optional timeout.
+
+This function uses the MutationObserver in JS to track whether a change in the DOM has occurred
+for the element given or it's subtree, this includes attribute changes.
+
+When a timeout is given, the Future will wait until the allotted time for a change in the DOM
+to occur. If no DOM change occurs then this function will panic.
+
+*/
+pub fn effect_dom<F>(element: &JsValue, action: F, timeout_ms: Option<u32>) -> JsFuture
+where
+    F: Fn() + 'static,
+{
+    let timeout = match timeout_ms {
+        Some(ms) => ms.into(),
+        None => JsValue::UNDEFINED,
+    };
+    let function = Closure::wrap(Box::new(action) as Box<dyn Fn()>);
+    JsFuture::from(until_mutation(
+        element,
+        function.as_ref().unchecked_ref(),
+        timeout,
+    ))
+}
+
+/**
+Asynchronous wait for a given amount of ms.
+
+This is a Rust Future which uses an underlying JS Promise and Timeout.
+This can be useful to assert something has occurred, or not, after a given amount of time -
+especially as you cannot use [sleep](std::thread::sleep) in a test using
+[`wasm_bindgen_test`](wasm_bindgen_testhttps://crates.io/crates/wasm-bindgen-test/).
+
+# Examples
+```no_run
+
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+async fn some_test_that_requires_waiting() {
+    // setup..
+    // wait 500ms - unwrap required
+    sap_utils::wait_ms(500).await.expect("Underlying JS not to throw exception");
+    // some asserts..
+}
+```
+*/
+pub async fn wait_ms(ms: u32) -> Result<(), JsValue> {
+    let _ = JsFuture::from(wait_promise(ms.into())).await?;
+    Ok(())
+}


### PR DESCRIPTION
These functions can be useful even when mocking is not required so have
been moved to the utils crate.