### PR TITLE
[Merged by Bors] - Getter and setter properties with js_sys Reflect

### DIFF
--- a/crates/sap-utils/js/sap-utils.js
+++ b/crates/sap-utils/js/sap-utils.js
@@ -25,19 +25,6 @@ function format_raw(node, level) {
 	return node;
 }
 
-export function get_value(element) {
-	return element.value
-}
-
-export function set_value(element, value) {
-	if (element.value !== undefined) {
-		element.value = value;
-		return true;
-	} else {
-		return false;
-	}
-}
-
 export function wait_promise(ms) {
 	return new Promise((resolve) => {
 		let wait = setTimeout(() => {

--- a/crates/sap-utils/src/html.rs
+++ b/crates/sap-utils/src/html.rs
@@ -3,23 +3,18 @@ use web_sys::Element;
 
 #[wasm_bindgen(module = "/js/sap-utils.js")]
 extern "C" {
-    fn get_value(element: &Element) -> JsValue;
-    fn set_value(element: &Element, value: JsValue) -> JsValue;
     fn format(str: JsValue) -> JsValue;
 }
 
 pub fn get_element_value<T: JsCast>(element: &T) -> Option<String> {
-    element
-        .dyn_ref::<Element>()
-        .and_then(|e| get_value(e).as_string())
+    js_sys::Reflect::get(&element.into(), &"value".into())
+        .ok()
+        .and_then(|v| v.as_string())
 }
 
 pub fn set_element_value<T: JsCast>(element: &T, value: &str) -> bool {
-    if let Some(element) = element.dyn_ref::<Element>() {
-        JsValue::TRUE == set_value(element, value.into())
-    } else {
-        false
-    }
+    js_sys::Reflect::set(&element.into(), &"value".into(), &value.into())
+        .expect("implementations of JsCast should be Objects")
 }
 
 pub fn format_html(html: &str) -> String {

--- a/crates/sap-utils/src/html.rs
+++ b/crates/sap-utils/src/html.rs
@@ -6,15 +6,23 @@ extern "C" {
     fn format(str: JsValue) -> JsValue;
 }
 
-pub fn get_element_value<T: JsCast>(element: &T) -> Option<String> {
-    js_sys::Reflect::get(&element.into(), &"value".into())
-        .ok()
-        .and_then(|v| v.as_string())
+macro_rules! get_js_property_impl {
+    ($getter:ident, $setter:ident, $property_name:literal) => {
+        pub fn $getter<T: JsCast>(element: &T) -> Option<String> {
+            js_sys::Reflect::get(&element.into(), &$property_name.into())
+                .ok()
+                .and_then(|v| v.as_string())
+        }
+
+        pub fn $setter<T: JsCast>(element: &T, value: &str) -> bool {
+            js_sys::Reflect::set(&element.into(), &$property_name.into(), &value.into())
+                .expect("implementations of JsCast should be Objects")
+        }
+    };
 }
 
-pub fn set_element_value<T: JsCast>(element: &T, value: &str) -> bool {
-    js_sys::Reflect::set(&element.into(), &"value".into(), &value.into())
-        .expect("implementations of JsCast should be Objects")
+get_js_property_impl! {
+    get_element_value, set_element_value, "value"
 }
 
 pub fn format_html(html: &str) -> String {


### PR DESCRIPTION
Instead of using manually built `wasm_bindgen` functions, we can just use `js_sys::Reflect` to get or set properties when the value is an `Object`. This reduces some clutter and avoids using js directly. 