### PR TITLE
[Merged by Bors] - Add assert_by_text query

### DIFF
--- a/examples/yew/counter/src/main.rs
+++ b/examples/yew/counter/src/main.rs
@@ -91,12 +91,12 @@ mod tests {
     fn test_counter() {
         let rendered = test_render! { <Model /> };
 
-        let inc_btn: HtmlButtonElement = rendered.get_by_text("+1").unwrap();
-        let dec_btn: HtmlButtonElement = rendered.get_by_text("-1").unwrap();
-        let dbl_inc_btn: HtmlButtonElement = rendered.get_by_text("+1, +1").unwrap();
+        let inc_btn: HtmlButtonElement = rendered.assert_by_text("+1");
+        let dec_btn: HtmlButtonElement = rendered.assert_by_text("-1");
+        let dbl_inc_btn: HtmlButtonElement = rendered.assert_by_text("+1, +1");
 
         // Keep counter as it will be updated
-        let counter: HtmlElement = rendered.get_by_text("0").unwrap();
+        let counter: HtmlElement = rendered.assert_by_text("0");
 
         // Confirm that the counter is at 0
         assert_text_content!(0, counter);

--- a/src/queries/by_text.rs
+++ b/src/queries/by_text.rs
@@ -179,6 +179,15 @@ pub trait ByText {
     fn get_by_text<'search, T>(&self, search: &'search str) -> Result<T, ByTextError<'search>>
     where
         T: JsCast;
+
+    /// A convenient method which unwraps the result of [`get_by_text`](ByText::get_by_text).
+    #[inline]
+    fn assert_by_text<T>(&self, search: &str) -> T
+    where
+        T: JsCast,
+    {
+        self.get_by_text(search).unwrap()
+    }
 }
 
 impl ByText for TestRender {


### PR DESCRIPTION
fixes #41

`assert_by_text` is a convenient method for calling `get_by_text` and unwrapping the `Result`.