### PR TITLE
[Merged by Bors] - Add assert_by_placeholder_text query

### DIFF
--- a/src/queries/by_placeholder_text.rs
+++ b/src/queries/by_placeholder_text.rs
@@ -177,6 +177,15 @@ pub trait ByPlaceholderText {
     ) -> Result<T, ByPlaceholderTextError<'search>>
     where
         T: JsCast;
+
+    /// A convenient method which unwraps the result of
+    /// [`get_by_placeholder_text`](ByPlaceholderText::get_by_placeholder_text).
+    fn assert_by_placeholder_text<T>(&self, search: &str) -> T
+    where
+        T: JsCast,
+    {
+        self.get_by_placeholder_text(search).unwrap()
+    }
 }
 
 impl ByPlaceholderText for TestRender {


### PR DESCRIPTION
fixes #40

`assert_by_placeholder_text` is a convenient method for calling
`get_by_placeholder_text` and unwrapping the `Result`.