### PR TITLE
Remove squash merge

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -3,4 +3,4 @@ status = [
 	"test",
 	"wasm-test-in-browser"
 ]
-use_squash_merge = true
+delete_merged_branches = true


### PR DESCRIPTION
Remove squash merge as it closes PRs and merges a staged version of them - this doesn't integrate nicely with Github. 
Prefer the extra commit each time.