### PR TITLE
Remove sap-yew dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,6 @@ wasm-bindgen = "0.2.74"
 [dev-dependencies]
 wasm-bindgen-test = "0.3.24"
 yew = { git = "https://github.com/yewstack/yew.git" }
-sap-yew = { git = "https://github.com/mc1098/sap-yew.git" }
-
 
 [dependencies.web-sys]
 version = "0.3.51"

--- a/examples/yew/counter/Cargo.toml
+++ b/examples/yew/counter/Cargo.toml
@@ -10,5 +10,4 @@ js-sys = "0.3.51"
 
 [dev-dependencies]
 sap = { path = "../../../" }
-sap-yew = { git = "https://github.com/mc1098/sap-yew.git" }
 wasm-bindgen-test = "0.3.24"

--- a/examples/yew/counter/src/main.rs
+++ b/examples/yew/counter/src/main.rs
@@ -7,7 +7,6 @@ pub enum Msg {
 }
 
 pub struct Model {
-    link: ComponentLink<Self>,
     value: i64,
 }
 
@@ -15,11 +14,11 @@ impl Component for Model {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
-        Self { link, value: 0 }
+    fn create(_: &Context<Self>) -> Self {
+        Self { value: 0 }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Increment => {
                 self.value += 1;
@@ -34,24 +33,20 @@ impl Component for Model {
         true
     }
 
-    fn change(&mut self, _props: Self::Properties) -> ShouldRender {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
         html! {
             <div>
                 <div class="panel">
                     // A button to send the Increment message
-                    <button class="button" onclick={self.link.callback(|_| Msg::Increment)}>
+                    <button class="button" onclick={ctx.link().callback(|_| Msg::Increment)}>
                         { "+1" }
                     </button>
                     // A button to send the Decrement message
-                    <button class="button" onclick={self.link.callback(|_| Msg::Decrement)}>
+                    <button class="button" onclick={ctx.link().callback(|_| Msg::Decrement)}>
                         { "-1" }
                     </button>
                     // A button to send the two Increment messages
-                    <button class="button" onclick={self.link.batch_callback(|_| vec![Msg::Increment, Msg::Increment])}>
+                    <button class="button" onclick={ctx.link().batch_callback(|_| vec![Msg::Increment, Msg::Increment])}>
                         { "+1, +1" }
                     </button>
 
@@ -81,7 +76,6 @@ fn main() {
 mod tests {
 
     use sap::prelude::*;
-    use sap_yew::test_render;
     use wasm_bindgen_test::*;
     use yew::web_sys::{HtmlButtonElement, HtmlElement};
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
@@ -89,7 +83,8 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_counter() {
-        let rendered = test_render! { <Model /> };
+        let rendered = QueryElement::new();
+        yew::start_app_in_element::<Model>(rendered.clone().into());
 
         let inc_btn: HtmlButtonElement = rendered.assert_by_text("+1");
         let dec_btn: HtmlButtonElement = rendered.assert_by_text("-1");

--- a/examples/yew/pub_sub/Cargo.toml
+++ b/examples/yew/pub_sub/Cargo.toml
@@ -12,5 +12,4 @@ serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 sap = { path = "../../.." }
-sap-yew = { git = "https://github.com/mc1098/sap-yew" }
 wasm-bindgen-test = "0.3.24"

--- a/examples/yew/pub_sub/src/main.rs
+++ b/examples/yew/pub_sub/src/main.rs
@@ -4,7 +4,7 @@ mod subscriber;
 
 use producer::Producer;
 use subscriber::Subscriber;
-use yew::{html, Component, ComponentLink, Html, ShouldRender};
+use yew::{html, Component, Context, Html};
 
 pub struct Model;
 
@@ -12,19 +12,11 @@ impl Component for Model {
     type Message = ();
     type Properties = ();
 
-    fn create(_props: Self::Properties, _link: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self
     }
 
-    fn change(&mut self, _msg: Self::Properties) -> ShouldRender {
-        false
-    }
-
-    fn update(&mut self, _props: Self::Message) -> ShouldRender {
-        unimplemented!()
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, _: &Context<Self>) -> Html {
         html! {
             <>
                 <Producer />
@@ -43,7 +35,6 @@ mod tests {
 
     use super::*;
     use sap::prelude::*;
-    use sap_yew::test_render;
     use wasm_bindgen_test::*;
     use yew::web_sys::HtmlButtonElement;
 
@@ -51,7 +42,8 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn click_producer_and_view_subscriber_message() {
-        let rendered = test_render! { <Model /> };
+        let rendered = QueryElement::new();
+        yew::start_app_in_element::<Model>(rendered.clone().into());
 
         // get subscriber heading message
         let sub_message: HtmlElement =

--- a/examples/yew/pub_sub/src/producer.rs
+++ b/examples/yew/pub_sub/src/producer.rs
@@ -7,7 +7,6 @@ pub enum Msg {
 }
 
 pub struct Producer {
-    link: ComponentLink<Producer>,
     event_bus: Dispatcher<EventBus>,
 }
 
@@ -15,18 +14,13 @@ impl Component for Producer {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_props: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {
-            link,
             event_bus: EventBus::dispatcher(),
         }
     }
 
-    fn change(&mut self, _props: Self::Properties) -> ShouldRender {
-        false
-    }
-
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::Clicked => {
                 self.event_bus
@@ -36,9 +30,9 @@ impl Component for Producer {
         }
     }
 
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
         html! {
-            <button onclick={self.link.callback(|_| Msg::Clicked)}>
+            <button onclick={ctx.link().callback(|_| Msg::Clicked)}>
                 { "PRESS ME" }
             </button>
         }

--- a/examples/yew/pub_sub/src/subscriber.rs
+++ b/examples/yew/pub_sub/src/subscriber.rs
@@ -1,5 +1,5 @@
 use super::event_bus::EventBus;
-use yew::{html, Component, ComponentLink, Html, ShouldRender};
+use yew::{html, Component, Context, Html};
 use yew_agent::{Bridge, Bridged};
 
 pub enum Msg {
@@ -15,18 +15,14 @@ impl Component for Subscriber {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_props: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(ctx: &Context<Self>) -> Self {
         Self {
             message: "No message yet.".to_owned(),
-            _producer: EventBus::bridge(link.callback(Msg::NewMessage)),
+            _producer: EventBus::bridge(ctx.link().callback(Msg::NewMessage)),
         }
     }
 
-    fn change(&mut self, _props: Self::Properties) -> ShouldRender {
-        false
-    }
-
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::NewMessage(s) => {
                 self.message = s;
@@ -35,7 +31,7 @@ impl Component for Subscriber {
         }
     }
 
-    fn view(&self) -> Html {
+    fn view(&self, _: &Context<Self>) -> Html {
         html! {
             <h1>{ &self.message }</h1>
         }

--- a/examples/yew/router/Cargo.toml
+++ b/examples/yew/router/Cargo.toml
@@ -12,5 +12,4 @@ yew-router = { git = "https://github.com/yewstack/yew.git" }
 
 [dev-dependencies]
 sap = { path = "../../.." }
-sap-yew = { git = "https://github.com/mc1098/sap-yew" }
 wasm-bindgen-test = "0.3.24"

--- a/examples/yew/router/src/main.rs
+++ b/examples/yew/router/src/main.rs
@@ -1,4 +1,4 @@
-use yew::prelude::*;
+use yew::{html::Scope, prelude::*};
 use yew_router::prelude::*;
 
 #[derive(Routable, PartialEq, Clone, Debug)]
@@ -19,21 +19,19 @@ pub enum Msg {
 }
 
 pub struct Model {
-    link: ComponentLink<Self>,
     navbar_active: bool,
 }
 impl Component for Model {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_props: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(_: &Context<Self>) -> Self {
         Self {
-            link,
             navbar_active: false,
         }
     }
 
-    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+    fn update(&mut self, _: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Msg::ToggleNavbar => {
                 self.navbar_active = !self.navbar_active;
@@ -42,14 +40,10 @@ impl Component for Model {
         }
     }
 
-    fn change(&mut self, _props: Self::Properties) -> ShouldRender {
-        false
-    }
-
-    fn view(&self) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
         html! {
             <>
-                { self.view_nav() }
+                { self.view_nav(ctx.link()) }
 
                 <main>
                     <Router<Route> render={Router::render(switch)} />
@@ -69,12 +63,8 @@ impl Component for Model {
     }
 }
 impl Model {
-    fn view_nav(&self) -> Html {
-        let Self {
-            ref link,
-            navbar_active,
-            ..
-        } = *self;
+    fn view_nav(&self, link: &Scope<Self>) -> Html {
+        let navbar_active = self.navbar_active;
 
         let active_class = if navbar_active { "is-active" } else { "" };
 
@@ -130,19 +120,11 @@ macro_rules! static_comp {
                 type Message = ();
                 type Properties = ();
 
-                fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+                fn create(_: &Context<Self>) -> Self {
                     Self
                 }
 
-                fn update(&mut self, _: Self::Message) -> ShouldRender {
-                    false
-                }
-
-                fn change(&mut self, _: Self::Properties) -> ShouldRender {
-                    false
-                }
-
-                fn view(&self) -> Html {
+                fn view(&self, _: &Context<Self>) -> Html {
                     $content
                 }
             }
@@ -186,11 +168,11 @@ mod tests {
     wasm_bindgen_test_configure!(run_in_browser);
 
     use sap::prelude::*;
-    use sap_yew::test_render;
 
     #[wasm_bindgen_test]
     fn route_test() {
-        let rendered: TestRender = test_render! { <Model /> };
+        let rendered = QueryElement::new();
+        yew::start_app_in_element::<Model>(rendered.clone().into());
 
         // Confirm that the Home component is loaded by checking for the "Home" heading.
         rendered.assert_by_aria_role::<HtmlElement>(AriaRole::Heading, "Home");

--- a/examples/yew/todo/Cargo.toml
+++ b/examples/yew/todo/Cargo.toml
@@ -14,5 +14,4 @@ gloo-storage = { git = "https://github.com/rustwasm/gloo.git" }
 
 [dev-dependencies]
 sap = { path = "../../.." }
-sap-yew = { git = "https://github.com/mc1098/sap-yew" }
 wasm-bindgen-test = "0.3.24"

--- a/examples/yew/v0.18.0/dashboard/Cargo.toml
+++ b/examples/yew/v0.18.0/dashboard/Cargo.toml
@@ -12,7 +12,6 @@ yew = { version = "0.18.0", features = ["toml"] }
 
 [dev-dependencies]
 sap = { path = "../../../.." }
-sap-yew = { git = "https://github.com/mc1098/sap-yew", branch = "v0.18.0" }
 sap-mock = { path = "../../../../crates/sap-mock" }
 sap-utils = { path = "../../../../crates/sap-utils" }
 wasm-bindgen-test = "0.3.24"

--- a/examples/yew/v0.18.0/dashboard/src/main.rs
+++ b/examples/yew/v0.18.0/dashboard/src/main.rs
@@ -239,7 +239,6 @@ mod tests {
     wasm_bindgen_test_configure!(run_in_browser);
 
     use sap::prelude::*;
-    use sap_yew::test_render;
     use yew::{
         format::{Binary, Text},
         web_sys::HtmlButtonElement,
@@ -247,7 +246,8 @@ mod tests {
 
     #[wasm_bindgen_test]
     async fn get_data() {
-        let rendered = test_render! { <Model /> };
+        let rendered = QueryElement::new();
+        App::<Model>::new().mount(rendered.clone().into());
 
         let mock = DataFromFile { value: 20 };
         // mock fetch to return mock value
@@ -269,7 +269,8 @@ mod tests {
 
     #[wasm_bindgen_test]
     async fn get_binary_data() {
-        let rendered = test_render! { <Model /> };
+        let rendered = QueryElement::new();
+        App::<Model>::new().mount(rendered.clone().into());
 
         let mock = DataFromFile { value: 50 };
         let _handle = sap_mock::mock_fetch(Ok(&mock));
@@ -286,7 +287,8 @@ mod tests {
 
     #[wasm_bindgen_test]
     async fn get_binary_toml() {
-        let rendered = test_render! { <Model /> };
+        let rendered = QueryElement::new();
+        App::<Model>::new().mount(rendered.clone().into());
 
         let mock: Text = Toml(&DataFromFile { value: 230 }).into();
         let _handle = sap_mock::mock_fetch(Ok(&mock.unwrap()));
@@ -303,7 +305,9 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn connect_to_ws_send_and_recieve() {
-        let rendered = test_render! { <Model /> };
+        let rendered = QueryElement::new();
+        App::<Model>::new().mount(rendered.clone().into());
+
         let controller = sap_mock::mock_ws(0);
 
         let connect_to_ws_btn = rendered
@@ -346,7 +350,8 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn connect_to_ws_send_and_recieve_binary() {
-        let rendered = test_render! { <Model /> };
+        let rendered = QueryElement::new();
+        App::<Model>::new().mount(rendered.clone().into());
         let controller = sap_mock::mock_ws(0);
 
         let connect_to_ws_btn = rendered

--- a/src/asserts.rs
+++ b/src/asserts.rs
@@ -47,7 +47,6 @@ macro_rules! assert_text_content {
 mod tests {
 
     use crate::prelude::*;
-    use sap_yew::test_render;
 
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
@@ -56,31 +55,23 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn assert_div_has_text_content() {
-        let rendered = test_render! {
-            <div id="mydiv">
-                { "div text content!" }
-            </div>
-        };
+        let render = QueryElement::new();
+        render.set_inner_html("<div id=\"mydiv\">div text content!</div>");
 
-        let result = rendered.query_selector("#mydiv").unwrap().unwrap();
+        let result = render.query_selector("#mydiv").unwrap().unwrap();
         assert_text_content!("div text content!", result);
     }
 
     #[wasm_bindgen_test]
     fn text_content_does_include_child_text_content() {
-        let rendered = test_render! {
-            <div id="mydiv">
-                { "text content " }
-                <strong>
-                    { "is broken up!" }
-                </strong>
-            </div>
-        };
+        let render = QueryElement::new();
+        render
+            .set_inner_html("<div id=\"mydiv\">text content <strong>is broken up!</strong></div>");
 
-        let not_found = rendered.get_by_text::<Element>("text content is broken up!");
+        let not_found = render.get_by_text::<Element>("text content is broken up!");
         assert!(not_found.is_err());
 
-        let result = rendered.query_selector("#mydiv").unwrap().unwrap();
+        let result = render.query_selector("#mydiv").unwrap().unwrap();
         assert_text_content!("text content is broken up!", result);
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -211,9 +211,9 @@ impl DblClick for EventTarget {
 Dispatches a [`InputEvent`] with the `data` given, to the event target.
 
 Input events can only be fired on the following:
-- [`HtmlInputElement`]
-- [`HtmlSelectElement`]
-- [`HtmlTextAreaElement`]
+- [`HtmlInputElement`](web_sys::HtmlInputElement)
+- [`HtmlSelectElement`](web_sys::HtmlSelectElement)
+- [`HtmlTextAreaElement`](web_sys::HtmlTextAreaElement)
 
 Using the function on other elements will do nothing!
 
@@ -722,7 +722,6 @@ mod tests {
     use yew::prelude::*;
 
     struct KeyDemo {
-        link: ComponentLink<Self>,
         last_key_pressed: Option<String>,
     }
 
@@ -730,30 +729,25 @@ mod tests {
         type Message = KeyboardEvent;
         type Properties = ();
 
-        fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+        fn create(_: &Context<Self>) -> Self {
             Self {
-                link,
                 last_key_pressed: None,
             }
         }
 
-        fn update(&mut self, msg: Self::Message) -> ShouldRender {
+        fn update(&mut self, _: &Context<Self>, msg: Self::Message) -> bool {
             self.last_key_pressed = Some(msg.key());
             true
         }
 
-        fn change(&mut self, _props: Self::Properties) -> ShouldRender {
-            false
-        }
-
-        fn view(&self) -> Html {
+        fn view(&self, ctx: &Context<Self>) -> Html {
             let default = "None".to_owned();
             let last_key_value = self.last_key_pressed.as_ref().unwrap_or(&default);
             html! {
                 <>
                     <p>{ last_key_value }</p>
                     <label for="input">{ "input label" }</label>
-                    <input id="input" placeholder="key" type="text" onkeydown={self.link.callback(|e| e)} />
+                    <input id="input" placeholder="key" type="text" onkeydown={ctx.link().callback(|e| e)} />
                 </>
             }
         }
@@ -761,17 +755,15 @@ mod tests {
 
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
-    use crate::{assert_text_content, TestRender};
-    use sap_yew::test_render;
+    use crate::{assert_text_content, QueryElement};
 
     use super::*;
     use crate::prelude::*;
 
     #[wasm_bindgen_test]
     fn sim_typing_to_input_and_enter_to_confirm() {
-        let rendered = test_render! {
-            <KeyDemo />
-        };
+        let rendered = QueryElement::new();
+        yew::start_app_in_element::<KeyDemo>(rendered.clone().into());
 
         let last_key_value: HtmlElement = rendered.get_by_text("None").unwrap();
         let input: HtmlInputElement = rendered.get_by_placeholder_text("key").unwrap();
@@ -795,22 +787,14 @@ mod tests {
     struct InputDemo;
 
     impl Component for InputDemo {
-        type Message = InputData;
+        type Message = ();
         type Properties = ();
 
-        fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+        fn create(_: &Context<Self>) -> Self {
             Self
         }
 
-        fn update(&mut self, _: Self::Message) -> ShouldRender {
-            false
-        }
-
-        fn change(&mut self, _props: Self::Properties) -> ShouldRender {
-            false
-        }
-
-        fn view(&self) -> Html {
+        fn view(&self, _: &Context<Self>) -> Html {
             html! {
                 <>
                     <input placeholder="key" type="text" />
@@ -821,9 +805,8 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn type_to_input() {
-        let rendered = test_render! {
-            <InputDemo />
-        };
+        let rendered = QueryElement::new();
+        yew::start_app_in_element::<InputDemo>(rendered.clone().into());
 
         let input: HtmlInputElement = rendered.get_by_placeholder_text("key").unwrap();
 
@@ -838,9 +821,8 @@ mod tests {
             static FLAG: Cell<bool> = Default::default();
         }
 
-        let rendered = test_render! {
-            <InputDemo />
-        };
+        let rendered = QueryElement::new();
+        yew::start_app_in_element::<InputDemo>(rendered.clone().into());
 
         let input: HtmlInputElement = rendered.get_by_placeholder_text("key").unwrap();
 

--- a/src/queries/by_aria.rs
+++ b/src/queries/by_aria.rs
@@ -182,7 +182,7 @@ use std::fmt::{Debug, Display};
 use wasm_bindgen::JsCast;
 use web_sys::{Element, Node};
 
-use crate::{RawNodeListIter, TestRender};
+use crate::{QueryElement, RawNodeListIter};
 
 /**
 Enables querying elements generically by ARIA roles, properties, and state.
@@ -223,8 +223,6 @@ pub trait ByAria {
     Code:
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -232,14 +230,8 @@ pub trait ByAria {
 
     #[wasm_bindgen_test]
     fn get_button_by_role() {
-        let rendered: TestRender = // feature dependent rendering
-            # test_render! {
-                # <div>
-                #   <div id="not-mybtn">
-                #       <button id="mybtn">{ "Click me!" }</button>
-                #   </div>
-                # </div>
-            # };
+        let rendered: QueryElement = // feature dependent rendering
+            # QueryElement::new();
 
         let button: HtmlButtonElement = rendered
             .get_by_aria_role(AriaRole::Button, "Click me!")
@@ -263,8 +255,6 @@ pub trait ByAria {
     Code:
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -272,12 +262,8 @@ pub trait ByAria {
 
     #[wasm_bindgen_test]
     fn get_button_by_role() {
-        let rendered: TestRender = // feature dependent rendering
-            # test_render! {
-                # <div>
-                    # <input id="toggle-all" type="checkbox" aria-label="Toggle all todo items" />
-                # </div>
-            # };
+        let rendered: QueryElement = // feature dependent rendering
+            # QueryElement::new();
 
         let checkbox: HtmlInputElement = rendered
             .get_by_aria_role(AriaRole::Checkbox, "Toggle all todo items")
@@ -341,8 +327,6 @@ pub trait ByAria {
     Code:
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -350,15 +334,8 @@ pub trait ByAria {
 
     #[wasm_bindgen_test]
     fn get_required_input_by_name() {
-        let rendered: TestRender = // feature dependent rendering
-            # test_render! {
-                # <form>
-                #   <label for="user-email">{ "Email:" }</label>
-                #   <input type="email" id="user-email" required=true />
-                #   <label for="user-password">{ "Password:" }</label>
-                #   <input type="password" id="user-password" required=true />
-                # </form>
-            # };
+        let rendered: QueryElement = // feature dependent rendering
+            # QueryElement::new();
 
         let email_input: HtmlInputElement = rendered
             .get_by_aria_prop(AriaProperty::Required(true), "Email:")
@@ -385,8 +362,6 @@ pub trait ByAria {
     Code:
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -394,14 +369,8 @@ pub trait ByAria {
 
     #[wasm_bindgen_test]
     fn get_button_aria_label() {
-        let rendered: TestRender = // feature dependent rendering
-            # test_render! {
-                # <div>
-                    # <div id="not-mybtn">
-                        # <button id="mybtn" aria-label="ok"/>
-                    # </div>
-                # </div>
-            # };
+        let rendered: QueryElement = // feature dependent rendering
+            # QueryElement::new();
 
         let button: HtmlButtonElement = rendered
             .get_by_aria_prop(AriaProperty::Label("ok".to_owned()), None)
@@ -459,8 +428,6 @@ pub trait ByAria {
     Code:
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -468,13 +435,8 @@ pub trait ByAria {
 
     #[wasm_bindgen_test]
     fn get_invalid_spelling_input() {
-        let rendered: TestRender = // feature dependent rendering
-            # test_render! {
-                # <form>
-                    # <input id="best-pet" aria-invalid="spelling" value="doge" aria-label="best pet" />
-                    # <input id="second-best-pet" value="cat" aria-label="second best pet" />
-                # </form>
-            # };
+        let rendered: QueryElement = // feature dependent rendering
+            # QueryElement::new();
 
         let spelling_error_input: HtmlInputElement = rendered
             .get_by_aria_state(AriaState::Invalid(InvalidToken::Spelling), "best pet")
@@ -541,7 +503,7 @@ where
     }
 }
 
-impl ByAria for TestRender {
+impl ByAria for QueryElement {
     fn get_by_aria_role<T>(&self, role: AriaRole, name: &str) -> Result<T, Error>
     where
         T: JsCast,
@@ -632,7 +594,7 @@ impl std::error::Error for ByAriaError {
 #[cfg(test)]
 mod tests {
 
-    use sap_yew::test_render;
+    use crate::make_element_with_html_string;
 
     use super::*;
     use sap_aria::InvalidToken;
@@ -642,14 +604,17 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn get_by_button_role_with_text_content() {
-        let rendered = test_render! {
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"
             <div>
                 <div id="not-mybtn">
-                    { "click me" }
-                    <button id="mybtn">{ "click me!" }</button>
+                    click me
+                <button id="mybtn">click me!</button>
                 </div>
             </div>
-        };
+        "#,
+        )
+        .into();
         let button: HtmlButtonElement = rendered
             .get_by_aria_role(AriaRole::Button, "click me!")
             .unwrap();
@@ -659,13 +624,17 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn get_by_aria_label() {
-        let rendered = test_render! {
+        // No text content in button
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"
             <div>
                 <div id="not-mybtn">
-                    <button id="mybtn" aria-label="ok" /> // No text on button
+                    <button id="mybtn" aria-label="ok" />
                 </div>
             </div>
-        };
+        "#,
+        )
+        .into();
 
         let button: HtmlButtonElement = rendered
             .get_by_aria_prop(AriaProperty::Label("ok".to_owned()), None)
@@ -676,11 +645,14 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn get_by_aria_disabled_state() {
-        let rendered = test_render! {
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"
             <div>
                 <input type="email" id="my-input" aria-disabled="true" />
             </div>
-        };
+        "#,
+        )
+        .into();
 
         let input: HtmlInputElement = rendered
             .get_by_aria_state(AriaState::Disabled(true), None)
@@ -691,12 +663,12 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn get_single_input_with_spelling_error() {
-        let rendered = test_render! {
+        let rendered: QueryElement = make_element_with_html_string(r#"
             <form>
                 <input id="best-pet" aria-label="best pet" aria-invalid="spelling" value="doge" />
                 <input id="second-best-pet" aria-label="second best pet" aria-invalid="false" value="cat"  />
             </form>
-        };
+        "#).into();
         let spelling_error_input: HtmlInputElement = rendered
             .get_by_aria_state(AriaState::Invalid(InvalidToken::Spelling), "best pet")
             .unwrap();
@@ -706,11 +678,14 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn get_input_by_role_with_aria_label() {
-        let rendered = test_render! {
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"
             <div>
                 <input id="myinput" type="text" aria-label="username" />
             </div>
-        };
+        "#,
+        )
+        .into();
 
         let input: HtmlInputElement = rendered
             .get_by_aria_role(AriaRole::TextBox, "username")
@@ -721,14 +696,15 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn get_button_by_role_with_aria_labelledby() {
-        let rendered = test_render! {
-            <>
-                <div id="button-label" >
-                    { "My custom button label" }
-                </div>
-                <button aria-labelledby="button-label" />
-            </>
-        };
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"
+            <div id="button-label">
+                My custom button label
+            </div>
+            <button aria-labelledby="button-label" />
+        "#,
+        )
+        .into();
 
         let button: HtmlButtonElement = rendered
             .get_by_aria_role(AriaRole::Button, "My custom button label")
@@ -742,14 +718,17 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn get_input_by_role_with_label() {
-        let rendered = test_render! {
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"
             <div>
                 <div>
-                    <label for="my-input">{ "My input label" }</label>
+                    <label for="my-input">My input label</label>
                 </div>
                 <input id="my-input" type="search" />
             </div>
-        };
+        "#,
+        )
+        .into();
 
         let input: HtmlInputElement = rendered
             .get_by_aria_role(AriaRole::Searchbox, "My input label")
@@ -760,12 +739,15 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn get_img_by_role_with_alt() {
-        let rendered = test_render! {
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"
             <div>
                 <img id="no" src="first-img.jpg" />
                 <img id="yes" src="somg-img.jpg" alt="The best image ever!" />
             </div>
-        };
+        "#,
+        )
+        .into();
 
         let img: HtmlImageElement = rendered
             .get_by_aria_role(AriaRole::Image, "The best image ever!")
@@ -776,12 +758,15 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn get_errors() {
-        let rendered = test_render! {
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"
             <label for="my-input">
-                { "My Input" }
+                My Input
                 <input id="my-input" type="text" />
             </label>
-        };
+        "#,
+        )
+        .into();
 
         let result = rendered.get_by_aria_role::<HtmlInputElement>(AriaRole::TextBox, "my input");
 

--- a/src/queries/by_display_value.rs
+++ b/src/queries/by_display_value.rs
@@ -1,16 +1,16 @@
 /*!
-Supports finding: [`HtmlInputElement`], [`HtmlSelectElement`], [`HtmlTextAreaElement`] generically
-by `display value`.
+Supports finding: [`HtmlInputElement`](web_sys::HtmlInputElement), [`HtmlSelectElement`](web_sys::HtmlSelectElement),
+[`HtmlTextAreaElement`](web_sys::HtmlTextAreaElement) generically by `display value`.
 
 # Display value
 
 The `display value` for each element:
-- [`HtmlInputElement`]\:
+- [`HtmlInputElement`](web_sys::HtmlInputElement)\:
     ```html
     <input type="text" value="Welcome" />
                               ^^^^^^^ the "display value"
     ```
-- [`HtmlSelectElement`]\:
+- [`HtmlSelectElement`](web_sys::HtmlSelectElement)\:
 
     The `display value`s possible are listed by the `option` elements - the current `display value`
     will be whichever option is selected by the user.
@@ -26,7 +26,7 @@ The `display value` for each element:
     default will normally be the first `option`[^note].
 
     [^note] _Needs to be confirmed that this is the standard_
-- [`HtmlTextAreaElement`]\:
+- [`HtmlTextAreaElement`](web_sys::HtmlTextAreaElement)\:
 
     The `display value` will be current text found in the textarea element.
     ```html
@@ -39,15 +39,15 @@ The `display value` for each element:
 
 # Generics
 Each trait function supports generics for convenience and to help narrow the scope of the search. If
-you are querying for a [`HtmlInputElement`] by `display value` then you won't find either
-[`HtmlSelectElement`], [`HtmlTextAreaElement`].
+you are querying for a [`HtmlInputElement`](web_sys::HtmlInputElement) by `display value` then you won't find either
+[`HtmlSelectElement`](web_sys::HtmlSelectElement), [`HtmlTextAreaElement`](web_sys::HtmlTextAreaElement).
 
 In [`Sap`](crate) the [`HtmlElement`](web_sys::HtmlElement) can be used as a "catch all" generic
 type[^note].
 
 [^note] _[`Element`](web_sys::Element) and [`Node`](web_sys::Node) can also be used as a 'catch all'
 type, however, [`HtmlElement`](web_sys::HtmlElement) has more useful functions for making assertions
-or performing certain actions, such as [`click`](web_sys::HtmlElement::click)._
+or performing certain actions, such as [`click`](web_sys::HtmlElement::click())._
 
 # What is [`JsCast`]?
 
@@ -60,7 +60,7 @@ use std::fmt::{Debug, Display};
 use wasm_bindgen::JsCast;
 use web_sys::Node;
 
-use crate::{Error, RawNodeListIter, TestRender};
+use crate::{Error, QueryElement, RawNodeListIter};
 
 /**
 Enables querying elements by `display value`.
@@ -72,9 +72,9 @@ pub trait ByDisplayValue {
     Get a generic element by the display value.
 
     The possible elements that can be returned are:
-    - [`HtmlInputElement`]
-    - [`HtmlSelectElement`]
-    - [`HtmlTextAreaElement`]
+    - [`HtmlInputElement`](web_sys::HtmlInputElement)
+    - [`HtmlSelectElement`](web_sys::HtmlSelectElement)
+    - [`HtmlTextAreaElement`](web_sys::HtmlTextAreaElement)
 
     Using one of the generic types above as `T` will essentially skip the other two types of
     elements - if you want to find the very first element that matches the display value then use
@@ -100,11 +100,9 @@ pub trait ByDisplayValue {
     ## Get input by display value
 
     The first element with the display value of "Welcome" is the textarea, however, this function
-    will return the last element because of the [`HtmlInputElement`] generic.
+    will return the last element because of the [`HtmlInputElement`](web_sys::HtmlInputElement) generic.
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -112,17 +110,8 @@ pub trait ByDisplayValue {
 
     #[wasm_bindgen_test]
     fn get_input_by_display_value() {
-        let rendered: TestRender = // feature dependent rendering
-        # test_render! {
-            # <div id="my-display-value-elements">
-            #   <textarea id="greeting-textarea">{ "Welcome" }</textarea>
-            #   <select id="greeting-select">
-            #       <option value="Welcome" selected=true>{ "Welcome" }</option>
-            #       <option value="Hello">{ "Hello" }</option>
-            #   </select>
-            #   <input id="greeting-input" type="text" value="Welcome" />
-            # </div>
-        # };
+        let rendered: QueryElement = // feature dependent rendering
+        # QueryElement::new();
         let input: HtmlInputElement = rendered
             .get_by_display_value("Welcome")
             .unwrap();
@@ -134,11 +123,9 @@ pub trait ByDisplayValue {
     ## Get select by display value
 
     The first element with the display value of "Welcome" is the textarea, however, this function
-    will return the second element because of the [`HtmlSelectElement`] generic.
+    will return the second element because of the [`HtmlSelectElement`](web_sys::HtmlSelectElement) generic.
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -146,17 +133,8 @@ pub trait ByDisplayValue {
 
     #[wasm_bindgen_test]
     fn get_select_by_display_value() {
-        let rendered: TestRender = // feature dependent rendering
-        # test_render! {
-            # <div id="my-display-value-elements">
-            #   <textarea id="greeting-textarea">{ "Welcome" }</textarea>
-            #   <select id="greeting-select">
-            #       <option value="Welcome" selected=true>{ "Welcome" }</option>
-            #       <option value="Hello">{ "Hello" }</option>
-            #   </select>
-            #   <input id="greeting-input" type="text" value="Welcome" />
-            # </div>
-        # };
+        let rendered: QueryElement = // feature dependent rendering
+        # QueryElement::new();
         let select = rendered
             .get_by_display_value::<HtmlSelectElement>("Welcome") // can use turbo fish
             .unwrap();
@@ -172,8 +150,6 @@ pub trait ByDisplayValue {
 
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -181,17 +157,8 @@ pub trait ByDisplayValue {
 
     #[wasm_bindgen_test]
     fn get_text_area_by_display_value() {
-        let rendered: TestRender = // feature dependent rendering
-        # test_render! {
-            # <div id="my-display-value-elements">
-            #   <textarea id="greeting-textarea">{ "Welcome" }</textarea>
-            #   <select id="greeting-select">
-            #       <option value="Welcome" selected=true>{ "Welcome" }</option>
-            #       <option value="Hello">{ "Hello" }</option>
-            #   </select>
-            #   <input id="greeting-input" type="text" value="Welcome" />
-            # </div>
-        # };
+        let rendered: QueryElement = // feature dependent rendering
+        # QueryElement::new();
         let text_area: HtmlTextAreaElement = rendered
             .get_by_display_value("Welcome")
             .unwrap();
@@ -207,8 +174,6 @@ pub trait ByDisplayValue {
 
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -216,17 +181,8 @@ pub trait ByDisplayValue {
 
     #[wasm_bindgen_test]
     fn get_text_area_by_display_value() {
-        let rendered: TestRender = // feature dependent rendering
-        # test_render! {
-            # <div id="my-display-value-elements">
-            #   <textarea id="greeting-textarea">{ "Welcome" }</textarea>
-            #   <select id="greeting-select">
-            #       <option value="Welcome" selected=true>{ "Welcome" }</option>
-            #       <option value="Hello">{ "Hello" }</option>
-            #   </select>
-            #   <input id="greeting-input" type="text" value="Welcome" />
-            # </div>
-            # };
+        let rendered: QueryElement = // feature dependent rendering
+        # QueryElement::new();
         let element: HtmlElement = rendered
             .get_by_display_value("Welcome")
             .unwrap();
@@ -251,15 +207,12 @@ pub trait ByDisplayValue {
     }
 }
 
-impl ByDisplayValue for TestRender {
+impl ByDisplayValue for QueryElement {
     fn get_by_display_value<T>(&self, search: &str) -> Result<T, Error>
     where
         T: JsCast,
     {
-        let elements = self
-            .root_element
-            .query_selector_all("input, select, textarea")
-            .ok();
+        let elements = self.query_selector_all("input, select, textarea").ok();
 
         let display_values = RawNodeListIter::<T>::new(elements).filter_map(|element| {
             sap_utils::get_element_value(&element).map(|value| (value, element))
@@ -345,14 +298,16 @@ mod tests {
     use super::*;
     use web_sys::{Element, HtmlInputElement, HtmlTextAreaElement};
 
-    use crate::TestRender;
-    use sap_yew::test_render;
+    use crate::{make_element_with_html_string, QueryElement};
 
     #[wasm_bindgen_test]
     fn get_input_by_display_value() {
-        let rendered = test_render! {
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"
             <input type="text" id="greeting" value="Welcome" />
-        };
+        "#,
+        )
+        .into();
 
         let input: HtmlInputElement = rendered.get_by_display_value("Welcome").unwrap();
         assert_eq!("greeting", input.id());
@@ -360,12 +315,13 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn get_text_area_due_to_type() {
-        let rendered = test_render! {
-            <>
-                <input type="text" id="input" value="hello" />
-                <textarea id="textarea" value="hello" />
-            </>
-        };
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"
+            <input type="text" id="input" value="hello" />
+            <textarea id="textarea">hello</textarea>
+        "#,
+        )
+        .into();
 
         let text_area: HtmlTextAreaElement = rendered.get_by_display_value("hello").unwrap();
         assert_eq!("textarea", text_area.id());
@@ -379,9 +335,12 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn get_errors() {
-        let rendered = test_render! {
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"
             <input type="text" value="this is it!" />
-        };
+        "#,
+        )
+        .into();
 
         let result = rendered.get_by_display_value::<HtmlInputElement>("this isn't it!");
 
@@ -394,13 +353,11 @@ mod tests {
             Err(error) => {
                 let expected = format!(
                     "\nNo exact match found for a display value of: '{}'.\nA similar match was found in the following HTML:{}",
-                    // "\nNo exact match found for a display value of: '{}'\nDid you mean to find this Element:\n\t{}\n",
                     "this isn't it!",
                     r#"
-<input type="text">
-^^^^^^^^^^^^^^^^^^^ Did you mean to find this element?
+<input type="text" value="this is it!">
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Did you mean to find this element?
 "#
-                    // "<input type=\"text\">"
                 );
 
                 assert_eq!(expected, format!("{:?}", error));
@@ -409,11 +366,14 @@ mod tests {
 
         drop(rendered);
 
-        let rendered = test_render! {
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"
             <span>
-                { "Not my bio!" }
+                Not my bio!
             </span>
-        };
+        "#,
+        )
+        .into();
 
         let result = rendered.get_by_display_value::<HtmlTextAreaElement>("My bio!");
 
@@ -422,7 +382,6 @@ mod tests {
             Err(err) => {
                 let expected = format!(
                     "\nNo element found with a display value equal or similar to '{}' in the following HTML:{}",
-                    // "\nNo element found with a display value equal or similar to '{}'\n",
                     "My bio!",
                     r#"
 <span>Not my bio!</span>

--- a/src/queries/by_label_text.rs
+++ b/src/queries/by_label_text.rs
@@ -41,7 +41,7 @@ use std::fmt::Display;
 use wasm_bindgen::JsCast;
 use web_sys::HtmlLabelElement;
 
-use crate::{Error, TestRender};
+use crate::{Error, QueryElement};
 
 /**
 Enables queries by `label text`.
@@ -101,8 +101,6 @@ pub trait ByLabelText {
     Code:
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -110,16 +108,8 @@ pub trait ByLabelText {
 
     #[wasm_bindgen_test]
     fn get_input_by_label_text() {
-        let rendered: TestRender = // feature dependent rendering
-            # test_render! {
-            # <div>
-            #   <form>
-            #       <label for="new-todo">{ "What need to be done?" }</label>
-            #       <br />
-            #       <input id="new-todo" value={"hi!"} />
-            #   </form>
-            # </div>
-            # };
+        let rendered: QueryElement = // feature dependent rendering
+            # QueryElement::new();
         let input: HtmlInputElement = rendered
             .get_by_label_text("What needs to be done?")
             .expect("To find the input by label text");
@@ -145,8 +135,6 @@ pub trait ByLabelText {
     Code:
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -154,16 +142,8 @@ pub trait ByLabelText {
 
     #[wasm_bindgen_test]
     fn label_not_found() {
-        let rendered: TestRender = // feature dependent rendering
-        # test_render! {
-            # <div>
-            #   <form>
-            #       <label for="new-todo">{ "What doesn't need to be done?" }</label>
-            #       <br />
-            #       <input id="new-todo" value={"hi!"} />
-            #   </form>
-            # </div>
-        # };
+        let rendered: QueryElement = // feature dependent rendering
+        # QueryElement::new();
         let result = rendered
             .get_by_label_text::<HtmlElement>("What needs to be done?");
 
@@ -189,8 +169,6 @@ pub trait ByLabelText {
     Code:
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -198,16 +176,8 @@ pub trait ByLabelText {
 
     #[wasm_bindgen_test]
     fn label_found_but_no_matching_input_element() {
-        let rendered: TestRender = // feature dependent rendering
-        # test_render! {
-            # <div>
-            #   <form>
-            #       <label for="new-todo">{ "What needs to be done?" }</label>
-            #       <br />
-            #       <input id="typo-on-id" value="hi!" />
-            #   </form>
-            # </div>
-        # };
+        let rendered: QueryElement = // feature dependent rendering
+        # QueryElement::new();
         let result = rendered
             .get_by_label_text::<HtmlElement>("What needs to be done?");
 
@@ -280,8 +250,6 @@ pub trait ByLabelText {
     Code:
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -289,16 +257,8 @@ pub trait ByLabelText {
 
     #[wasm_bindgen_test]
     fn get_input_by_label_text() {
-        let rendered: TestRender = // feature dependent rendering
-            # test_render! {
-            # <div>
-            #   <form>
-            #       <label for="new-todo">{ "What need to be done?" }</label>
-            #       <br />
-            #       <input id="new-todo" value={"hi!"} />
-            #   </form>
-            # </div>
-            # };
+        let rendered: QueryElement = // feature dependent rendering
+            # QueryElement::new();
         // turbo fish is recommended over this approach
         let (input, label): (HtmlInputElement, HtmlLabelElement) = rendered
             .get_by_label_text_inc("What needs to be done?")
@@ -325,8 +285,6 @@ pub trait ByLabelText {
     Code:
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -334,16 +292,8 @@ pub trait ByLabelText {
 
     #[wasm_bindgen_test]
     fn label_not_found() {
-        let rendered: TestRender = // feature dependent rendering
-        # test_render! {
-            # <div>
-            #   <form>
-            #       <label for="new-todo">{ "What doesn't need to be done?" }</label>
-            #       <br />
-            #       <input id="new-todo" value={"hi!"} />
-            #   </form>
-            # </div>
-        # };
+        let rendered: QueryElement = // feature dependent rendering
+        # QueryElement::new();
         let result = rendered
             .get_by_label_text_inc::<HtmlElement>("What needs to be done?");
 
@@ -369,8 +319,6 @@ pub trait ByLabelText {
     Code:
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -378,16 +326,8 @@ pub trait ByLabelText {
 
     #[wasm_bindgen_test]
     fn label_found_but_no_matching_input_element() {
-        let rendered: TestRender = // feature dependent rendering
-        # test_render! {
-            # <div>
-            #   <form>
-            #       <label for="new-todo">{ "What needs to be done?" }</label>
-            #       <br />
-            #       <input id="typo-on-id" value="hi!" />
-            #   </form>
-            # </div>
-        # };
+        let rendered: QueryElement = // feature dependent rendering
+        # QueryElement::new();
         let result = rendered
             .get_by_label_text_inc::<HtmlElement>("What needs to be done?");
 
@@ -409,12 +349,12 @@ pub trait ByLabelText {
     }
 }
 
-impl ByLabelText for TestRender {
+impl ByLabelText for QueryElement {
     fn get_by_label_text_inc<T>(&self, search: &str) -> Result<(T, HtmlLabelElement), Error>
     where
         T: JsCast,
     {
-        let labels = match self.root_element.query_selector_all("label") {
+        let labels = match self.query_selector_all("label") {
             Ok(labels) => labels,
             Err(_) => {
                 return Err(Box::new(ByLabelTextError::LabelNotFound((
@@ -561,46 +501,54 @@ pub mod tests {
     use wasm_bindgen_test::*;
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
     use super::*;
-    use crate::TestRender;
-    use sap_yew::test_render;
+    use crate::{make_element_with_html_string, QueryElement};
     use web_sys::{HtmlElement, HtmlInputElement};
 
-    fn input_label_text() -> TestRender {
-        test_render! {
+    fn input_label_text() -> QueryElement {
+        make_element_with_html_string(
+            r#"""
             <div>
                 <form>
-                    <label for="new-todo">{"What needs to be done?"}</label>
+                    <label for="new-todo">What needs to be done?</label>
                     <br />
-                    <input id="new-todo" value={"hi!"} />
+                    <input id="new-todo" value="hi!" />
                 </form>
             </div>
-        }
+        """#,
+        )
+        .into()
     }
 
-    fn input_label_text_label_after_input() -> TestRender {
-        test_render! {
+    fn input_label_text_label_after_input() -> QueryElement {
+        make_element_with_html_string(
+            r#"""
             <div>
                 <form>
-                    <input id="new-todo" value={"hi!"} />
+                    <input id="new-todo" value="hi!" />
                     <br />
-                    <label for="new-todo">{"What needs to be done?"}</label>
+                    <label for="new-todo">What needs to be done?</label>
                 </form>
             </div>
-        }
+        """#,
+        )
+        .into()
     }
 
-    fn input_label_text_different_parents() -> TestRender {
-        test_render! {
+    fn input_label_text_different_parents() -> QueryElement {
+        make_element_with_html_string(
+            r#"""
             <div>
                 <form>
                     <div>
-                        <label for="new-todo">{"What needs to be done?"}</label>
+                        <label for="new-todo">What needs to be done?</label>
                     </div>
                     <br />
-                    <input id="new-todo" value={"hi!"} />
+                    <input id="new-todo" value="hi!" />
                 </form>
             </div>
-        }
+        """#,
+        )
+        .into()
     }
 
     #[wasm_bindgen_test]
@@ -621,15 +569,18 @@ pub mod tests {
 
     #[wasm_bindgen_test]
     fn no_element_found_when_id_and_for_do_not_match() {
-        let rendered = test_render! {
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"""
             <div>
                 <form>
-                    <label for="new-todoz">{ "What needs to be done?" }</label>
+                    <label for="new-todoz">What needs to be done?</label>
                     <br />
-                    <input id="new_todo" value={"hi!"} />
+                    <input id="new_todo" value="hi!" />
                 </form>
             </div>
-        };
+        """#,
+        )
+        .into();
 
         let result = rendered.get_by_label_text::<HtmlElement>("What needs to be done?");
         assert!(result.is_err());
@@ -637,15 +588,18 @@ pub mod tests {
 
     #[wasm_bindgen_test]
     fn text_not_found_when_search_term_not_found_in_label() {
-        let rendered = test_render! {
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"""
             <div>
                 <form>
-                    <label for="new-todo">{ "What doesn't need to be done?" }</label>
+                    <label for="new-todo">What doesn't need to be done?</label>
                     <br />
-                    <input id="new-todo" value={"hi!"} />
+                    <input id="new-todo" value="hi!" />
                 </form>
             </div>
-        };
+        """#,
+        )
+        .into();
 
         let result = rendered.get_by_label_text::<HtmlElement>("What needs to be done?");
 
@@ -655,12 +609,15 @@ pub mod tests {
     #[wasm_bindgen_test]
     fn input_value_change() {
         let label_text = "What needs to be done?";
-        let rendered = test_render! {
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"""
             <>
-                <label for="todo">{ "What needs to be done?" }</label>
+                <label for="todo">What needs to be done?</label>
                 <input type="text" id="todo" value="" />
             </>
-        };
+        """#,
+        )
+        .into();
 
         let new_value = "Gardening";
 

--- a/src/queries/by_placeholder_text.rs
+++ b/src/queries/by_placeholder_text.rs
@@ -44,7 +44,7 @@ use std::fmt::{Debug, Display};
 use wasm_bindgen::JsCast;
 use web_sys::{HtmlInputElement, HtmlTextAreaElement, Node};
 
-use crate::{Error, RawNodeListIter, TestRender};
+use crate::{Error, QueryElement, RawNodeListIter};
 
 /**
 Enables querying by `placeholder text`.
@@ -82,8 +82,6 @@ pub trait ByPlaceholderText {
 
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -91,13 +89,8 @@ pub trait ByPlaceholderText {
 
     #[wasm_bindgen_test]
     fn get_input_by_placeholder_text() {
-        let rendered: TestRender = // feature dependent rendering
-        # test_render! {
-            # <div>
-            #   <input id="username-input" placeholder="Username" />
-            #   <textarea id="username-textarea" placeholder="Username" />
-            # </div>
-        # };
+        let rendered: QueryElement = // feature dependent rendering
+        # QueryElement::new();
         let input: HtmlInputElement = rendered
             .get_by_placeholder_text("Username")
             .unwrap();
@@ -113,8 +106,6 @@ pub trait ByPlaceholderText {
 
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -122,13 +113,8 @@ pub trait ByPlaceholderText {
 
     #[wasm_bindgen_test]
     fn get_text_area_by_placeholder_text() {
-        let rendered: TestRender = // feature dependent rendering
-        # test_render! {
-            # <div>
-            #   <input id="username-input" placeholder="Username" />
-            #   <textarea id="username-textarea" placeholder="Username" />
-            # </div>
-        # };
+        let rendered: QueryElement = // feature dependent rendering
+        # QueryElement::new();
         let text_area: HtmlTextAreaElement = rendered
             .get_by_placeholder_text("Username")
             .unwrap();
@@ -144,8 +130,6 @@ pub trait ByPlaceholderText {
 
     ```no_run
     # fn main() {}
-    # use yew::prelude::*;
-    # use sap_yew::test_render;
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
     use sap::prelude::*;
@@ -153,13 +137,8 @@ pub trait ByPlaceholderText {
 
     #[wasm_bindgen_test]
     fn get_first_element_by_placeholder_text() {
-        let rendered: TestRender = // feature dependent rendering
-        # test_render! {
-            # <div>
-            #   <input id="username-input" placeholder="Username" />
-            #   <textarea id="username-textarea" placeholder="Username" />
-            # </div>
-        # };
+        let rendered: QueryElement = // feature dependent rendering
+        # QueryElement::new();
         let element: HtmlElement = rendered
             .get_by_placeholder_text("Username")
             .unwrap();
@@ -185,15 +164,12 @@ pub trait ByPlaceholderText {
     }
 }
 
-impl ByPlaceholderText for TestRender {
+impl ByPlaceholderText for QueryElement {
     fn get_by_placeholder_text<T>(&self, search: &str) -> Result<T, Error>
     where
         T: JsCast,
     {
-        let holders = self
-            .root_element
-            .query_selector_all(":placeholder-shown")
-            .ok();
+        let holders = self.query_selector_all(":placeholder-shown").ok();
 
         let holders = RawNodeListIter::<T>::new(holders).filter_map(|holder| match holder
             .dyn_into::<HtmlInputElement>(
@@ -283,16 +259,18 @@ mod tests {
     use web_sys::{Element, HtmlElement};
 
     use super::*;
-    use crate::TestRender;
-    use sap_yew::test_render;
+    use crate::{make_element_with_html_string, QueryElement};
 
     #[wasm_bindgen_test]
     fn get_input_by_placeholder_text() {
-        let rendered = test_render! {
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"""
             <div>
                 <input id="34" placeholder="Username" />
             </div>
-        };
+        """#,
+        )
+        .into();
 
         let result: HtmlElement = rendered.get_by_placeholder_text("Username").unwrap();
         assert_eq!("34", result.id());
@@ -300,11 +278,14 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn get_textarea_by_placeholder_text() {
-        let rendered = test_render! {
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"
             <div>
-                <textarea id="23" placeholder="Enter bio here" />
+                <textarea id="23" placeholder="Enter bio here"></textarea>
             </div>
-        };
+        "#,
+        )
+        .into();
 
         let result: HtmlElement = rendered.get_by_placeholder_text("Enter bio here").unwrap();
         assert_eq!("23", result.id());
@@ -316,9 +297,12 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn get_errors() {
-        let rendered = test_render! {
-            <input type="text" placeholder="Username" />
-        };
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"
+            <input placeholder="Username" type="text" />
+        "#,
+        )
+        .into();
 
         let result = rendered.get_by_placeholder_text::<HtmlInputElement>("usrname");
 
@@ -342,11 +326,14 @@ mod tests {
 
         drop(rendered);
 
-        let rendered = test_render! {
+        let rendered: QueryElement = make_element_with_html_string(
+            r#"
             <div>
-                { "Click me!" }
+                Click me!
             </div>
-        };
+        "#,
+        )
+        .into();
 
         let result = rendered.get_by_placeholder_text::<HtmlTextAreaElement>("Enter bio");
 


### PR DESCRIPTION
Remove reference of sap-yew in the sap crate and examples in an effort to decouple from Yew.

Updated examples.