### PR TITLE
Change `by_text` to use inner text for searching

### DIFF
--- a/src/asserts.rs
+++ b/src/asserts.rs
@@ -51,8 +51,6 @@ mod tests {
     use wasm_bindgen_test::*;
     wasm_bindgen_test_configure!(run_in_browser);
 
-    use web_sys::Element;
-
     #[wasm_bindgen_test]
     fn assert_div_has_text_content() {
         let render = QueryElement::new();
@@ -67,9 +65,6 @@ mod tests {
         let render = QueryElement::new();
         render
             .set_inner_html("<div id=\"mydiv\">text content <strong>is broken up!</strong></div>");
-
-        let not_found = render.get_by_text::<Element>("text content is broken up!");
-        assert!(not_found.is_err());
 
         let result = render.query_selector("#mydiv").unwrap().unwrap();
         assert_text_content!("text content is broken up!", result);

--- a/src/queries/by_text.rs
+++ b/src/queries/by_text.rs
@@ -1,21 +1,17 @@
 /*!
-Supports finding elements generically by their text node.
+Supports finding elements generically by their inner text.
 
-The text node of an element is the text raw text between the opening and closing tags.
+The text of an element is the text raw text between the opening and closing tags.
 
 ```html
-<div>
+<div id="1">
     div text node
-    <button>button text node</button>
+    <button id="2">button text node</button>
 </div>
 ```
-
-Text nodes are broken up when using elements such as `strong`:
-```html
-<div>
-    div text node <strong>strong text node</strong>
-</div>
-```
+The elements will have the following inner text:
+1 - "div text nodebutton text node"
+2 - "button text node"
 
 # Generics
 Each trait function supports generics for convenience and to help narrow the scope of the search. If
@@ -41,19 +37,19 @@ use std::{
 };
 
 use wasm_bindgen::{prelude::Closure, JsCast};
-use web_sys::{Node, NodeFilter, TreeWalker};
+use web_sys::{HtmlElement, Node, NodeFilter, TreeWalker};
 
 use crate::{Error, QueryElement};
 
 /**
-Enables queries by text node.
+Enables queries by inner text.
 
 _See each trait function for examples._
 */
 pub trait ByText {
     /**
 
-    Get a generic element by the text node.
+    Get a generic element by the inner text.
 
     Using one of the generic types above as `T` will essentially skip the other two types of
     elements - if you want to find the very first element that matches the display value then use
@@ -67,7 +63,6 @@ pub trait ByText {
     Rendered html:
     ```html
     <div>
-        Hello, <strong>World!</strong>
         <div id="text-div">Hello, World!</div>
         <button id="text-button">Hello, World!</button>
         <label id="text-label">Hello, World!</label>
@@ -149,8 +144,6 @@ pub trait ByText {
         assert_eq!("text-div", element.id());
     }
     ```
-    This might seem surprising but the outer div element contains a text node "Hello, " as the strong
-    element breaks the text node - take care trying to find elements by text.
     */
     fn get_by_text<T>(&self, search: &str) -> Result<T, Error>
     where
@@ -173,18 +166,13 @@ impl ByText for QueryElement {
     {
         let search_string = search.to_owned();
 
-        let filter_on_text_value = move |node: Node| {
-            if node
-                .parent_element()
-                .and_then(|e| e.dyn_into::<T>().ok())
-                .is_some()
-            {
-                node.text_content()
-                    .map(|text| text == search_string)
-                    .unwrap_or_default()
-            } else {
-                false
-            }
+        let filter_on_text_value = move |node: Node| match node.parent_element().and_then(|e| {
+            e.dyn_into::<T>()
+                .ok()
+                .map(|e| e.unchecked_into::<HtmlElement>())
+        }) {
+            Some(e) => e.inner_text() == search_string,
+            None => false,
         };
 
         let walker = create_filtered_tree_walker(self, WhatToShow::ShowText, filter_on_text_value);
@@ -220,13 +208,13 @@ impl ByText for QueryElement {
 }
 
 /**
-An error indicating that no text node was an equal match for a given search term.
+An error indicating that no inner text was an equal match for a given search term.
 */
 pub enum ByTextError {
-    /// No text node could be found with the given search term.
+    /// No inner text could be found with the given search term.
     NotFound(String, String),
     /**
-    No text node with an exact match for the search term could be found, however, a text node
+    No inner text with an exact match for the search term could be found, however, a inner text
     with a similar content as the search term was found.
 
     This should help find elements when a user has made a typo in either the test or the
@@ -336,6 +324,22 @@ mod tests {
     use web_sys::{Element, HtmlButtonElement, HtmlLabelElement};
 
     #[wasm_bindgen_test]
+    fn search_multi_text_node_element() {
+        let rendered: QueryElement =
+            make_element_with_html_string("<div id=\"mydiv\">One: </div>").into();
+        let document = web_sys::window()
+            .expect("No global window object")
+            .document()
+            .expect("No global document object");
+
+        let div = document.get_element_by_id("mydiv").unwrap();
+        let text = document.create_text_node("Two");
+        div.append_child(&text).expect("Unable to append text node");
+
+        rendered.assert_by_text::<Element>("One: Two");
+    }
+
+    #[wasm_bindgen_test]
     fn text_search() {
         let test: QueryElement = make_element_with_html_string(
             r#"""
@@ -374,7 +378,7 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    fn by_text_uses_text_nodes_not_text_content() {
+    fn by_text_uses_inner_text_not_text_content() {
         let rendered: QueryElement = make_element_with_html_string(
             r#"""
             <div>
@@ -386,10 +390,7 @@ mod tests {
         .into();
         // can't find `Hello, World!` as they are two distinct text nodes :(
         let not_found = rendered.get_by_text::<Element>("Hello, World!");
-        assert!(not_found.is_err());
-
-        let found = rendered.get_by_text::<Element>("Hello, ");
-        assert!(found.is_ok())
+        assert!(not_found.is_ok());
     }
 
     #[wasm_bindgen_test]


### PR DESCRIPTION
`by_text` was searching for individual text nodes but this makes it
difficult to use with templating frameworks that build an elements text
using multiple text nodes.