### PR TITLE
Add Sycamore counter example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,12 @@ features = [
 	"TreeWalker",
 ]
 
+[dev-dependencies.web-sys]
+version = "0.3"
+features = [
+	"Text",
+]
+
 [features]
 default = []
 
@@ -54,6 +60,7 @@ members = [
 	"examples/yew/pub_sub",
 	"examples/yew/router",
 	"examples/yew/todo",
+	"examples/sycamore/counter",
 ]
 
 [patch.crates-io]

--- a/examples/sycamore/counter/Cargo.toml
+++ b/examples/sycamore/counter/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "sycamore-counter"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sycamore = "0.6"
+log = "0.4"
+
+[dev-dependencies]
+sap = { path = "../../../" }
+wasm-bindgen-test = "0.3"
+
+[dev-dependencies.web-sys]
+version = "0.3"
+features = [
+	"HtmlButtonElement",
+	"HtmlElement",
+]

--- a/examples/sycamore/counter/index.html
+++ b/examples/sycamore/counter/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<title>Counter</title>
+
+	<style>
+		body {
+			font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+		}
+	</style>
+</head>
+
+<body></body>
+
+</html>

--- a/examples/sycamore/counter/src/main.rs
+++ b/examples/sycamore/counter/src/main.rs
@@ -1,0 +1,64 @@
+use sycamore::prelude::*;
+
+#[component(App<G>)]
+fn app() -> Template<G> {
+    let counter = Signal::new(0);
+
+    create_effect(cloned!((counter) => move || {
+        log::info!("Counter value: {}", *counter.get());
+    }));
+
+    let increment = cloned!((counter) => move |_| counter.set(*counter.get() + 1));
+
+    let reset = cloned!((counter) => move |_| counter.set(0));
+
+    template! {
+        div {
+            "Counter demo"
+            p(class="value") {
+                "Value: "
+                (counter.get())
+            }
+            button(class="increment", on:click=increment) {
+                "Increment"
+            }
+            button(class="reset", on:click=reset) {
+                "Reset"
+            }
+        }
+    }
+}
+
+fn main() {
+    sycamore::render(|| template! { App() });
+}
+
+#[cfg(test)]
+mod tests {
+
+    use sap::prelude::*;
+    use wasm_bindgen_test::*;
+    wasm_bindgen_test_configure!(run_in_browser);
+    use super::*;
+    use web_sys::{HtmlButtonElement, HtmlElement};
+
+    #[wasm_bindgen_test]
+    fn can_count_and_reset() {
+        let rendered = QueryElement::new();
+        sycamore::render_to(|| template! { App() }, &rendered);
+
+        let inc_btn: HtmlButtonElement = rendered.assert_by_text("Increment");
+        let counter: HtmlElement = rendered.assert_by_text("Value: 0");
+
+        inc_btn.click();
+        assert_text_content!("Value: 1", counter);
+
+        inc_btn.click();
+        inc_btn.click();
+        assert_text_content!("Value: 3", counter);
+
+        let reset_btn: HtmlButtonElement = rendered.assert_by_text("Reset");
+        reset_btn.click();
+        assert_text_content!("Value: 0", counter);
+    }
+}

--- a/examples/yew/counter/Cargo.toml
+++ b/examples/yew/counter/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "counter"
+name = "yew-counter"
 version = "0.1.0"
 authors = ["mc1098 <m.cripps1@uni.brighton.ac.uk>"]
 edition = "2018"


### PR DESCRIPTION
Update package names to prefix the framework used in the example to
avoid conflicts of package names in workspace members