### PR TITLE
Add parent traversal for `ByText` queries

### DIFF
--- a/crates/sap-utils/src/lev_distance.rs
+++ b/crates/sap-utils/src/lev_distance.rs
@@ -32,6 +32,10 @@ pub(crate) fn lev_distance(me: &str, t: &str) -> usize {
     dcol[t_last + 1]
 }
 
+pub fn is_close(a: &str, b: &str) -> bool {
+    lev_distance(a, b) < 4
+}
+
 pub fn closest<T, I, F>(search: &str, iter: I, to_key: F) -> Option<T>
 where
     I: Iterator<Item = T>,

--- a/crates/sap-utils/src/lib.rs
+++ b/crates/sap-utils/src/lib.rs
@@ -2,7 +2,7 @@ mod html;
 mod lev_distance;
 
 pub use html::{format_html, format_html_with_closest, get_element_value, set_element_value};
-pub use lev_distance::closest;
+pub use lev_distance::{closest, is_close};
 
 use js_sys::Function;
 use wasm_bindgen::{prelude::*, JsCast};


### PR DESCRIPTION
`ByText` queries will now traverse up the element tree to find an
element with an innerText that matches the query.

Fixes #67 