### PR TITLE
Add `Sycamore` todo example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ members = [
 	"examples/yew/router",
 	"examples/yew/todo",
 	"examples/sycamore/counter",
+	"examples/sycamore/todo",
 ]
 
 [patch.crates-io]

--- a/examples/sycamore/todo/Cargo.toml
+++ b/examples/sycamore/todo/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "sycamore-todo"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+log = "0.4"
+sycamore = { version = "0.6", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+uuid = { version = "0.8", features = ["v4", "wasm-bindgen", "serde"] }
+wasm-bindgen = "0.2"
+
+[dependencies.web-sys]
+version = "0.3"
+features = [
+	"InputEvent",
+	"KeyboardEvent",
+	"Location",
+	"Storage",
+]
+
+[dev-dependencies]
+sap = { path = "../../../" }
+wasm-bindgen-test = "0.3"

--- a/examples/sycamore/todo/index.html
+++ b/examples/sycamore/todo/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<meta charset="utf-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<title>Sycamore • TodoMVC</title>
+
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/todomvc-common@1.0.5/base.css" />
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/todomvc-app-css@2.1.2/index.css" />
+</head>
+
+<body></body>
+
+</html>

--- a/examples/sycamore/todo/src/copyright.rs
+++ b/examples/sycamore/todo/src/copyright.rs
@@ -1,0 +1,18 @@
+use sycamore::prelude::*;
+
+#[component(Copyright<G>)]
+pub fn copyright() -> Template<G> {
+    template! {
+        footer(class="info") {
+            p { "Double click to edit a todo" }
+            p {
+                "Created by "
+                a(href="https://github.com/lukechu10", target="_blank") { "lukechu10" }
+            }
+            p {
+                "Part of "
+                a(href="http://todomvc.com") { "TodoMVC" }
+            }
+        }
+    }
+}

--- a/examples/sycamore/todo/src/footer.rs
+++ b/examples/sycamore/todo/src/footer.rs
@@ -1,0 +1,62 @@
+use sycamore::prelude::*;
+
+use crate::{AppState, Filter};
+
+#[component(Footer<G>)]
+pub fn footer(app_state: AppState) -> Template<G> {
+    let items_text = cloned!((app_state) => move || {
+        match app_state.todos_left() {
+            1 => "item",
+            _ => "items"
+        }
+    });
+
+    let has_completed_todos = create_selector(cloned!((app_state) => move || {
+        app_state.todos_left() < app_state.todos.get().len()
+    }));
+
+    let app_state2 = app_state.clone();
+    let app_state3 = app_state.clone();
+
+    template! {
+        footer(class="footer") {
+            span(class="todo-count") {
+                strong { (app_state.todos_left()) }
+                span { " " (items_text()) " left" }
+            }
+            ul(class="filters") {
+                Indexed(IndexedProps {
+                    iterable: Signal::new(vec![Filter::All, Filter::Active, Filter::Completed]).handle(),
+                    template: cloned!((app_state2) => move |filter| {
+                        let selected = cloned!((app_state2) => move || filter == *app_state2.filter.get());
+                        let set_filter = cloned!((app_state2) => move |filter| {
+                            app_state2.filter.set(filter)
+                        });
+
+                        template! {
+                            li {
+                                a(
+                                    class=if selected() { "selected" } else { "" },
+                                    href=filter.url(),
+                                    on:click=move |_| set_filter(filter),
+                                ) {
+                                    (format!("{:?}", filter))
+                                }
+                            }
+                        }
+                    })
+                })
+            }
+
+            (if *has_completed_todos.get() {
+                template! {
+                    button(class="clear-completed", on:click=cloned!((app_state3) => move |_| app_state3.clear_completed())) {
+                        "Clear completed"
+                    }
+                }
+            } else {
+                Template::empty()
+            })
+        }
+    }
+}

--- a/examples/sycamore/todo/src/header.rs
+++ b/examples/sycamore/todo/src/header.rs
@@ -1,0 +1,35 @@
+use sycamore::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::{Event, KeyboardEvent};
+
+use crate::AppState;
+
+#[component(Header<G>)]
+pub fn header(app_state: AppState) -> Template<G> {
+    let value = Signal::new(String::new());
+
+    let handle_submit = cloned!((app_state, value) => move |event: Event| {
+        let event: KeyboardEvent = event.unchecked_into();
+
+        if event.key() == "Enter" {
+            let mut task = value.get().as_ref().clone();
+            task = task.trim().to_string();
+
+            if !task.is_empty() {
+                app_state.add_todo(task);
+                value.set("".to_string());
+            }
+        }
+    });
+
+    template! {
+        header(class="header") {
+            h1 { "todos" }
+            input(class="new-todo",
+                placeholder="What needs to be done?",
+                bind:value=value,
+                on:keyup=handle_submit,
+            )
+        }
+    }
+}

--- a/examples/sycamore/todo/src/item.rs
+++ b/examples/sycamore/todo/src/item.rs
@@ -1,0 +1,117 @@
+use sycamore::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::{Event, HtmlInputElement, KeyboardEvent};
+
+use crate::{AppState, Todo};
+
+pub struct ItemProps {
+    pub todo: Signal<Todo>,
+    pub app_state: AppState,
+}
+
+#[component(Item<G>)]
+pub fn item(props: ItemProps) -> Template<G> {
+    let ItemProps { todo, app_state } = props;
+
+    let title = cloned!((todo) => move || todo.get().title.clone());
+    let completed = create_selector(cloned!((todo) => move || todo.get().completed));
+    let id = todo.get().id;
+
+    let editing = Signal::new(false);
+    let input_ref = NodeRef::<G>::new();
+    let value = Signal::new("".to_string());
+
+    let handle_input = cloned!((value) => move |event: Event| {
+        let target: HtmlInputElement = event.target().unwrap().unchecked_into();
+        value.set(target.value());
+    });
+
+    let toggle_completed = cloned!((todo) => move |_| {
+        todo.set(Todo {
+            completed: !todo.get().completed,
+            ..todo.get().as_ref().clone()
+        });
+    });
+
+    let handle_dblclick = cloned!((title, editing, input_ref, value) => move |_| {
+        editing.set(true);
+        input_ref.get::<DomNode>().unchecked_into::<HtmlInputElement>().focus().unwrap();
+        value.set(title());
+    });
+
+    let handle_blur = cloned!((todo, app_state, editing, value) => move || {
+        editing.set(false);
+
+        let mut value = value.get().as_ref().clone();
+        value = value.trim().to_string();
+
+        if value.is_empty() {
+            app_state.remove_todo(id);
+        } else {
+            todo.set(Todo {
+                title: value,
+                ..todo.get().as_ref().clone()
+            })
+        }
+    });
+
+    let handle_submit = cloned!((editing, input_ref, handle_blur, title) => move |event: Event| {
+        let event: KeyboardEvent = event.unchecked_into();
+        match event.key().as_str() {
+            "Enter" => handle_blur(),
+            "Escape" => {
+                input_ref.get::<DomNode>().unchecked_into::<HtmlInputElement>().set_value(&title());
+                editing.set(false);
+            },
+            _ => {}
+        }
+    });
+
+    let handle_destroy = cloned!((app_state) => move |_| {
+        app_state.remove_todo(id);
+    });
+
+    // We need a separate signal for checked because clicking the checkbox will detach the binding
+    // between the attribute and the view.
+    let checked = Signal::new(false);
+    create_effect(cloned!((completed, checked) => move || {
+        // Calling checked.set will also update the `checked` property on the input element.
+        checked.set(*completed.get())
+    }));
+
+    let class = cloned!((completed, editing) => move || {
+        format!("{} {}",
+            if *completed.get() { "completed" } else { "" },
+            if *editing.get() { "editing" } else { "" }
+        )
+    });
+
+    let todo_id = format!("todo-{}", id);
+    let todo_id_label = todo_id.clone();
+
+    template! {
+        li(class=class()) {
+            div(class="view") {
+                input(class="toggle", id=todo_id, type="checkbox", on:input=toggle_completed, bind:checked=checked)
+                label(for=todo_id_label, on:dblclick=handle_dblclick) {
+                    (title())
+                }
+                button(class="destroy", on:click=handle_destroy)
+            }
+
+            (if *editing.get() {
+                cloned!((todo, input_ref, handle_blur, handle_submit, handle_input) => template! {
+                    input(ref=input_ref,
+                        class="edit",
+                        value=todo.get().title.clone(),
+                        on:blur=move |_| handle_blur(),
+                        on:keyup=handle_submit,
+                        on:input=handle_input,
+                    )
+                })
+            } else {
+                Template::empty()
+            })
+        }
+    }
+}

--- a/examples/sycamore/todo/src/item.rs
+++ b/examples/sycamore/todo/src/item.rs
@@ -87,16 +87,18 @@ pub fn item(props: ItemProps) -> Template<G> {
     });
 
     let todo_id = format!("todo-{}", id);
-    let todo_id_label = todo_id.clone();
+    let todo_id_list = todo_id.clone();
+    let todo_checkbox_id = format!("{}-check", todo_id);
+    let checkbox_label_id = todo_checkbox_id.clone();
 
     template! {
-        li(class=class()) {
+        li(id=todo_id_list, class=class()) {
             div(class="view") {
-                input(class="toggle", id=todo_id, type="checkbox", on:input=toggle_completed, bind:checked=checked)
-                label(for=todo_id_label, on:dblclick=handle_dblclick) {
+                input(class="toggle", id=todo_checkbox_id, type="checkbox", on:input=toggle_completed, bind:checked=checked)
+                label(for=checkbox_label_id, on:dblclick=handle_dblclick) {
                     (title())
                 }
-                button(class="destroy", on:click=handle_destroy)
+                button(aria-controls=todo_id, class="destroy", on:click=handle_destroy)
             }
 
             (if *editing.get() {

--- a/examples/sycamore/todo/src/list.rs
+++ b/examples/sycamore/todo/src/list.rs
@@ -27,6 +27,7 @@ pub fn list(app_state: AppState) -> Template<G> {
     template! {
         section(class="main") {
             input(
+                aria-label="toggle all todo items",
                 id="toggle-all",
                 class="toggle-all",
                 type="checkbox",

--- a/examples/sycamore/todo/src/list.rs
+++ b/examples/sycamore/todo/src/list.rs
@@ -1,0 +1,50 @@
+use sycamore::prelude::*;
+
+use crate::{AppState, Filter};
+
+#[component(List<G>)]
+pub fn list(app_state: AppState) -> Template<G> {
+    let todos_left = create_selector(cloned!((app_state) => move || {
+        app_state.todos_left()
+    }));
+
+    let filtered_todos = create_memo(cloned!((app_state) => move || {
+        app_state.todos.get().iter().filter(|todo| match *app_state.filter.get() {
+            Filter::All => true,
+            Filter::Active => !todo.get().completed,
+            Filter::Completed => todo.get().completed,
+        }).cloned().collect::<Vec<_>>()
+    }));
+
+    // We need a separate signal for checked because clicking the checkbox will detach the binding
+    // between the attribute and the view.
+    let checked = Signal::new(false);
+    create_effect(cloned!((checked) => move || {
+        // Calling checked.set will also update the `checked` property on the input element.
+        checked.set(*todos_left.get() == 0)
+    }));
+
+    template! {
+        section(class="main") {
+            input(
+                id="toggle-all",
+                class="toggle-all",
+                type="checkbox",
+                readonly=true,
+                bind:checked=checked,
+                on:input=cloned!((app_state) => move |_| app_state.toggle_complete_all())
+            )
+            label(for="toggle-all")
+
+            ul(class="todo-list") {
+                Keyed(KeyedProps {
+                    iterable: filtered_todos,
+                    template: move |todo| template! {
+                        crate::item::Item(crate::item::ItemProps { todo, app_state: app_state.clone() })
+                    },
+                    key: |todo| todo.get().id,
+                })
+            }
+        }
+    }
+}

--- a/examples/sycamore/todo/src/main.rs
+++ b/examples/sycamore/todo/src/main.rs
@@ -1,0 +1,227 @@
+mod copyright;
+mod footer;
+mod header;
+mod item;
+mod list;
+
+use serde::{Deserialize, Serialize};
+use sycamore::prelude::*;
+use uuid::Uuid;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Todo {
+    title: String,
+    completed: bool,
+    id: Uuid,
+}
+
+#[derive(Debug, Clone)]
+pub struct AppState {
+    pub todos: Signal<Vec<Signal<Todo>>>,
+    pub filter: Signal<Filter>,
+}
+
+impl AppState {
+    fn add_todo(&self, title: String) {
+        self.todos.set(
+            self.todos
+                .get()
+                .as_ref()
+                .clone()
+                .into_iter()
+                .chain(Some(Signal::new(Todo {
+                    title,
+                    completed: false,
+                    id: Uuid::new_v4(),
+                })))
+                .collect(),
+        )
+    }
+
+    fn remove_todo(&self, id: Uuid) {
+        self.todos.set(
+            self.todos
+                .get()
+                .iter()
+                .filter(|todo| todo.get().id != id)
+                .cloned()
+                .collect(),
+        );
+    }
+
+    fn todos_left(&self) -> usize {
+        self.todos.get().iter().fold(
+            0,
+            |acc, todo| if todo.get().completed { acc } else { acc + 1 },
+        )
+    }
+
+    fn toggle_complete_all(&self) {
+        if self.todos_left() == 0 {
+            // make all todos active
+            for todo in self.todos.get().iter() {
+                if todo.get().completed {
+                    todo.set(Todo {
+                        completed: false,
+                        ..todo.get().as_ref().clone()
+                    })
+                }
+            }
+        } else {
+            // make all todos completed
+            for todo in self.todos.get().iter() {
+                if !todo.get().completed {
+                    todo.set(Todo {
+                        completed: true,
+                        ..todo.get().as_ref().clone()
+                    })
+                }
+            }
+        }
+    }
+
+    fn clear_completed(&self) {
+        self.todos.set(
+            self.todos
+                .get()
+                .iter()
+                .filter(|todo| !todo.get().completed)
+                .cloned()
+                .collect(),
+        );
+    }
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self {
+            todos: Signal::new(Vec::new()),
+            filter: Signal::new(Filter::All),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Filter {
+    All,
+    Active,
+    Completed,
+}
+
+impl Filter {
+    fn url(self) -> &'static str {
+        match self {
+            Filter::All => "#",
+            Filter::Active => "#/active",
+            Filter::Completed => "#/completed",
+        }
+    }
+
+    fn get_filter_from_hash() -> Self {
+        let hash = web_sys::window().unwrap().location().hash().unwrap();
+
+        match hash.as_str() {
+            "#/active" => Filter::Active,
+            "#/completed" => Filter::Completed,
+            _ => Filter::All,
+        }
+    }
+}
+
+const KEY: &str = "todos-sycamore";
+
+#[component(App<G>)]
+fn app() -> Template<G> {
+    let local_storage = web_sys::window()
+        .unwrap()
+        .local_storage()
+        .unwrap()
+        .expect("user has not enabled localStorage");
+
+    let todos = if let Ok(Some(app_state)) = local_storage.get_item(KEY) {
+        serde_json::from_str(&app_state).unwrap_or_else(|_| Signal::new(Vec::new()))
+    } else {
+        Signal::new(Vec::new())
+    };
+
+    let app_state = AppState {
+        todos,
+        filter: Signal::new(Filter::get_filter_from_hash()),
+    };
+
+    create_effect(cloned!((local_storage, app_state) => move || {
+        for todo in app_state.todos.get().iter() {
+            todo.get(); // subscribe to changes in all todos
+        }
+
+        local_storage.set_item(KEY, &serde_json::to_string(app_state.todos.get().as_ref()).unwrap()).unwrap();
+    }));
+
+    let todos_is_empty =
+        create_selector(cloned!((app_state) => move || app_state.todos.get().len() == 0));
+
+    template! {
+        div(class="todomvc-wrapper") {
+            section(class="todoapp") {
+                header::Header(app_state.clone())
+
+                (if !*todos_is_empty.get() {
+                    template! {
+                        list::List(app_state.clone())
+                        footer::Footer(app_state.clone())
+                    }
+                } else {
+                    Template::empty()
+                })
+            }
+
+            copyright::Copyright()
+        }
+    }
+}
+
+fn main() {
+    sycamore::render(|| template! { App() });
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use sap::{events::*, prelude::*, type_to};
+    use wasm_bindgen_test::*;
+    use web_sys::{HtmlButtonElement, HtmlElement, HtmlInputElement};
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
+    fn make_new_todo_item_complete_it_then_clear_completed() {
+        let rendered = QueryElement::new();
+        sycamore::render_to(|| template! { App() }, &rendered);
+
+        // get todo input
+        let input: HtmlInputElement = rendered.assert_by_placeholder_text("What needs to be done?");
+
+        // type 'Gardening' into input and confirm
+        type_to!(input, "Gardening", Key::Enter);
+
+        // // expecting the item left count to be 1
+        // let todo_left: HtmlElement = rendered.assert_by_text("1 item left");
+
+        // 'Gardening' todo item has been rendered - lets just get the completed checkbox
+        let checkbox: HtmlInputElement = rendered.assert_by_label_text("Gardening");
+        // confirm that our new todo items is not completed
+        assert!(!checkbox.checked());
+
+        // click the todo checkbox - marking it complete
+        checkbox.click();
+
+        // get clear completed button - it only appears after a todo has been marked as completed
+        let clear_completed_btn: HtmlButtonElement =
+            rendered.assert_by_aria_role(AriaRole::Button, "Clear completed");
+
+        // click to clear all completed todo items
+        clear_completed_btn.click();
+        // confirm that the todo item has been removed
+        assert!(!rendered.contains(Some(&checkbox)));
+    }
+}


### PR DESCRIPTION
Another example using `Sycamore` which highlighted a few issues with Sap.

Added the same Aria based modifications to this example as I did to yew so that it was easier to find certain elements - plus actually makes the example more accessible too :)