### PR TITLE
Remove element on assert fail

### DIFF
--- a/src/queries/by_aria.rs
+++ b/src/queries/by_aria.rs
@@ -283,10 +283,7 @@ pub trait ByAria {
     /// A convenient method which unwraps the result of [`get_by_aria_role`](ByAria::get_by_aria_role).
     fn assert_by_aria_role<T>(&self, role: AriaRole, name: &str) -> T
     where
-        T: JsCast,
-    {
-        self.get_by_aria_role(role, name).unwrap()
-    }
+        T: JsCast;
 
     /**
 
@@ -389,10 +386,7 @@ pub trait ByAria {
     fn assert_by_aria_prop<'name, S, T>(&self, property: AriaProperty, name: S) -> T
     where
         S: Into<Option<&'name str>>,
-        T: JsCast,
-    {
-        self.get_by_aria_prop(property, name).unwrap()
-    }
+        T: JsCast;
 
     /**
 
@@ -455,10 +449,7 @@ pub trait ByAria {
     fn assert_by_aria_state<'name, S, T>(&self, state: AriaState, name: S) -> T
     where
         S: Into<Option<&'name str>>,
-        T: JsCast,
-    {
-        self.get_by_aria_state(state, name).unwrap()
-    }
+        T: JsCast;
 }
 
 #[inline]
@@ -501,11 +492,34 @@ where
 }
 
 impl ByAria for QueryElement {
+    fn assert_by_aria_role<T>(&self, role: AriaRole, name: &str) -> T
+    where
+        T: JsCast,
+    {
+        let result = self.get_by_aria_role(role, name);
+        if result.is_err() {
+            self.remove();
+        }
+        result.unwrap()
+    }
+
     fn get_by_aria_role<T>(&self, role: AriaRole, name: &str) -> Result<T, Error>
     where
         T: JsCast,
     {
         get_by_aria_impl(self, role, name.into())
+    }
+
+    fn assert_by_aria_prop<'name, S, T>(&self, property: AriaProperty, name: S) -> T
+    where
+        S: Into<Option<&'name str>>,
+        T: JsCast,
+    {
+        let result = self.get_by_aria_prop(property, name);
+        if result.is_err() {
+            self.remove();
+        }
+        result.unwrap()
     }
 
     fn get_by_aria_prop<'name, S, T>(&self, prop: AriaProperty, name: S) -> Result<T, Error>
@@ -514,6 +528,18 @@ impl ByAria for QueryElement {
         T: JsCast,
     {
         get_by_aria_impl(self, prop, name.into())
+    }
+
+    fn assert_by_aria_state<'name, S, T>(&self, state: AriaState, name: S) -> T
+    where
+        S: Into<Option<&'name str>>,
+        T: JsCast,
+    {
+        let result = self.get_by_aria_state(state, name);
+        if result.is_err() {
+            self.remove();
+        }
+        result.unwrap()
     }
 
     fn get_by_aria_state<'name, S, T>(&self, state: AriaState, name: S) -> Result<T, Error>

--- a/src/queries/by_display_value.rs
+++ b/src/queries/by_display_value.rs
@@ -201,13 +201,21 @@ pub trait ByDisplayValue {
     /// [`get_by_display_value`](ByDisplayValue::get_by_display_value).
     fn assert_by_display_value<T>(&self, search: &str) -> T
     where
-        T: JsCast,
-    {
-        self.get_by_display_value(search).unwrap()
-    }
+        T: JsCast;
 }
 
 impl ByDisplayValue for QueryElement {
+    fn assert_by_display_value<T>(&self, search: &str) -> T
+    where
+        T: JsCast,
+    {
+        let result = self.get_by_display_value(search);
+        if result.is_err() {
+            self.remove();
+        }
+        result.unwrap()
+    }
+
     fn get_by_display_value<T>(&self, search: &str) -> Result<T, Error>
     where
         T: JsCast,

--- a/src/queries/by_label_text.rs
+++ b/src/queries/by_label_text.rs
@@ -198,7 +198,7 @@ pub trait ByLabelText {
     where
         T: JsCast,
     {
-        self.get_by_label_text(search).unwrap()
+        self.assert_by_label_text_inc(search).0
     }
 
     /**
@@ -343,13 +343,21 @@ pub trait ByLabelText {
     /// [`get_by_label_text_inc`](ByLabelText::get_by_label_text_inc).
     fn assert_by_label_text_inc<T>(&self, search: &str) -> (T, HtmlLabelElement)
     where
-        T: JsCast,
-    {
-        self.get_by_label_text_inc(search).unwrap()
-    }
+        T: JsCast;
 }
 
 impl ByLabelText for QueryElement {
+    fn assert_by_label_text_inc<T>(&self, search: &str) -> (T, HtmlLabelElement)
+    where
+        T: JsCast,
+    {
+        let result = self.get_by_label_text_inc(search);
+        if result.is_err() {
+            self.remove();
+        }
+        result.unwrap()
+    }
+
     fn get_by_label_text_inc<T>(&self, search: &str) -> Result<(T, HtmlLabelElement), Error>
     where
         T: JsCast,

--- a/src/queries/by_placeholder_text.rs
+++ b/src/queries/by_placeholder_text.rs
@@ -158,13 +158,21 @@ pub trait ByPlaceholderText {
     /// [`get_by_placeholder_text`](ByPlaceholderText::get_by_placeholder_text).
     fn assert_by_placeholder_text<T>(&self, search: &str) -> T
     where
-        T: JsCast,
-    {
-        self.get_by_placeholder_text(search).unwrap()
-    }
+        T: JsCast;
 }
 
 impl ByPlaceholderText for QueryElement {
+    fn assert_by_placeholder_text<T>(&self, search: &str) -> T
+    where
+        T: JsCast,
+    {
+        let result = self.get_by_placeholder_text(search);
+        if result.is_err() {
+            self.remove();
+        }
+        result.unwrap()
+    }
+
     fn get_by_placeholder_text<T>(&self, search: &str) -> Result<T, Error>
     where
         T: JsCast,

--- a/src/queries/by_text.rs
+++ b/src/queries/by_text.rs
@@ -150,13 +150,9 @@ pub trait ByText {
         T: JsCast;
 
     /// A convenient method which unwraps the result of [`get_by_text`](ByText::get_by_text).
-    #[inline]
     fn assert_by_text<T>(&self, search: &str) -> T
     where
-        T: JsCast,
-    {
-        self.get_by_text(search).unwrap()
-    }
+        T: JsCast;
 }
 
 fn first_text_node_in_inner_text_match<T>(node: &Node, query: &str, exact: bool) -> Option<T>
@@ -188,6 +184,18 @@ where
 }
 
 impl ByText for QueryElement {
+    #[inline]
+    fn assert_by_text<T>(&self, search: &str) -> T
+    where
+        T: JsCast,
+    {
+        let result = self.get_by_text(search);
+        if result.is_err() {
+            self.remove();
+        }
+        result.unwrap()
+    }
+
     fn get_by_text<T>(&self, search: &str) -> Result<T, Error>
     where
         T: JsCast,


### PR DESCRIPTION
Removes the element wrapped by `QueryElement` from the DOM. 

This is to try to help avoid environment poisoning when an assertion fails - it won't save us from environment poisoning but it could help some 🙃. 

Fixes #66