### PR TITLE
Refactor query Error enums

### DIFF
--- a/src/queries/by_display_value.rs
+++ b/src/queries/by_display_value.rs
@@ -230,17 +230,17 @@ impl ByDisplayValue for QueryElement {
             if search == dv {
                 Ok(e)
             } else {
-                Err(Box::new(ByDisplayValueError::Closest((
-                    search.to_owned(),
-                    self.inner_html(),
-                    e.unchecked_into(),
-                ))))
+                Err(Box::new(ByDisplayValueError::Closest {
+                    search_term: search.to_owned(),
+                    inner_html: self.inner_html(),
+                    closest_node: e.unchecked_into(),
+                }))
             }
         } else {
-            Err(Box::new(ByDisplayValueError::NotFound((
-                search.to_owned(),
-                self.inner_html(),
-            ))))
+            Err(Box::new(ByDisplayValueError::NotFound {
+                search_term: search.to_owned(),
+                inner_html: self.inner_html(),
+            }))
         }
     }
 }
@@ -248,9 +248,12 @@ impl ByDisplayValue for QueryElement {
 /**
 An error indicating that no element with a display value was an equal match for a given search term.
 */
-pub enum ByDisplayValueError {
+enum ByDisplayValueError {
     /// No element could be found with the given search term.
-    NotFound((String, String)),
+    NotFound {
+        search_term: String,
+        inner_html: String,
+    },
     /**
     No element display value was an exact match for the search term could be found, however, an
     element with a similar display value as the search term was found.
@@ -259,26 +262,37 @@ pub enum ByDisplayValueError {
     implementation being tested or when trying to find text with a dynamic number that may be
     incorrect
     */
-    Closest((String, String, Node)),
+    Closest {
+        search_term: String,
+        inner_html: String,
+        closest_node: Node,
+    },
 }
 
 impl Debug for ByDisplayValueError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ByDisplayValueError::NotFound((search, html)) => {
+            ByDisplayValueError::NotFound {
+                search_term,
+                inner_html,
+            } => {
                 write!(
                     f,
                     "\nNo element found with a display value equal or similar to '{}' in the following HTML:{}",
-                    search,
-                    sap_utils::format_html(html)
+                    search_term,
+                    sap_utils::format_html(inner_html)
                 )
             }
-            ByDisplayValueError::Closest((search, html, closest)) => {
+            ByDisplayValueError::Closest {
+                search_term,
+                inner_html,
+                closest_node,
+            } => {
                 write!(
                     f,
                     "\nNo exact match found for a display value of: '{}'.\nA similar match was found in the following HTML:{}",
-                    search,
-                    sap_utils::format_html_with_closest(html, closest.unchecked_ref()),
+                    search_term,
+                    sap_utils::format_html_with_closest(inner_html, closest_node.unchecked_ref()),
                 )
             }
         }


### PR DESCRIPTION
Refactor of error enums for improved readability, internally. Error enums are now private as all queries return dyn objects anyway. 